### PR TITLE
Fix/correct route localities

### DIFF
--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -64,7 +64,7 @@ func (s *ServerChi) Run(mysql *sql.DB) (err error) {
 	svcProduct := service.NewProductService(repoProduct)
 	svcWarehouse := service.NewWarehouseService(repoWarehouse)
 	svcEmployee := service.NewEmployeeDefault(repoEmployee, repoWarehouse)
-	svcCarry := service.NewCarryService(repoCarry)
+	svcCarry := service.NewCarryService(repoCarry, repoGeography)
 	svcGeography := service.NewGeographyService(repoGeography)
 	svcInboundOrder := service.NewInboundOrderService(repoInboundOrder, repoEmployee, repoWarehouse)
 

--- a/internal/router/carry.go
+++ b/internal/router/carry.go
@@ -11,8 +11,8 @@ func MountCarryRoutes(api chi.Router, hd *handler.CarryHandler) {
 	})
 }
 
-func MountCarryReportRoutes(api chi.Router, hd *handler.CarryHandler) {
-	api.Route("/localities", func(r chi.Router) {
-		r.Get("/reportCarries", hd.ReportCarries)
-	})
-}
+// func MountCarryReportRoutes(api chi.Router, hd *handler.CarryHandler) {
+// 	api.Route("/localities", func(r chi.Router) {
+// 		r.Get("/reportCarries", hd.ReportCarries)
+// 	})
+// }

--- a/internal/router/carry.go
+++ b/internal/router/carry.go
@@ -10,9 +10,3 @@ func MountCarryRoutes(api chi.Router, hd *handler.CarryHandler) {
 		r.Post("/", hd.Create)
 	})
 }
-
-// func MountCarryReportRoutes(api chi.Router, hd *handler.CarryHandler) {
-// 	api.Route("/localities", func(r chi.Router) {
-// 		r.Get("/reportCarries", hd.ReportCarries)
-// 	})
-// }

--- a/internal/router/geography.go
+++ b/internal/router/geography.go
@@ -5,9 +5,10 @@ import (
 	"github.com/varobledo_meli/W17-G10-Bootcamp.git/internal/handler"
 )
 
-func MountGeographyRoutes(api chi.Router, hd *handler.GeographyHandler) {
+func MountGeographyRoutes(api chi.Router, hd *handler.GeographyHandler, hdCarry *handler.CarryHandler) {
 	api.Route("/localities", func(r chi.Router) {
 		r.Post("/", hd.Create)
 		r.Get("/reportSellers", hd.CountSellersByLocality)
+		r.Get("/reportCarries", hdCarry.ReportCarries)
 	})
 }

--- a/internal/router/geography.go
+++ b/internal/router/geography.go
@@ -5,10 +5,10 @@ import (
 	"github.com/varobledo_meli/W17-G10-Bootcamp.git/internal/handler"
 )
 
-func MountGeographyRoutes(api chi.Router, hd *handler.GeographyHandler, hdCarry *handler.CarryHandler) {
+func MountGeographyRoutes(api chi.Router, hdGeography *handler.GeographyHandler, hdCarry *handler.CarryHandler) {
 	api.Route("/localities", func(r chi.Router) {
-		r.Post("/", hd.Create)
-		r.Get("/reportSellers", hd.CountSellersByLocality)
+		r.Post("/", hdGeography.Create)
+		r.Get("/reportSellers", hdGeography.CountSellersByLocality)
 		r.Get("/reportCarries", hdCarry.ReportCarries)
 	})
 }

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -32,8 +32,7 @@ func NewAPIRouter(
 		MountSellerRoutes(api, hdSeller)
 		MountEmployeeRoutes(api, hdEmployee)
 		MountCarryRoutes(api, hdCarry)
-		MountCarryReportRoutes(api, hdCarry)
-		MountGeographyRoutes(api, hdGeography)
+		MountGeographyRoutes(api, hdGeography, hdCarry)
 		MountInboundOrderRoutes(api, hdInboundOrder)
 	})
 

--- a/internal/service/carry.go
+++ b/internal/service/carry.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 
+	"github.com/varobledo_meli/W17-G10-Bootcamp.git/pkg/api/apperrors"
 	"github.com/varobledo_meli/W17-G10-Bootcamp.git/pkg/models/carry"
 )
 
@@ -23,6 +24,14 @@ func (s *CarryDefault) Create(ctx context.Context, c carry.Carry) (*carry.Carry,
 func (s *CarryDefault) GetCarriesReport(ctx context.Context, localityID *string) (interface{}, error) {
 	if localityID == nil {
 		return s.rp.GetCarriesCountByAllLocalities(ctx)
+	}
+
+	l, err := s.rpGeo.FindLocalityById(ctx, *localityID)
+	if err != nil {
+		return nil, err
+	}
+	if l == nil {
+		return nil, apperrors.NewAppError(apperrors.CodeNotFound, "locality not found")
 	}
 	return s.rp.GetCarriesCountByLocalityID(ctx, *localityID)
 }

--- a/internal/service/carry_interface.go
+++ b/internal/service/carry_interface.go
@@ -14,8 +14,12 @@ type CarryService interface {
 
 type CarryDefault struct {
 	rp repository.CarryRepository
+	rpGeo repository.GeographyRepository
 }
 
-func NewCarryService(rp repository.CarryRepository) *CarryDefault {
-	return &CarryDefault{rp: rp}
+func NewCarryService(rp repository.CarryRepository, rpGeo repository.GeographyRepository) *CarryDefault {
+	return &CarryDefault{
+		rp:    rp,
+		rpGeo: rpGeo,
+	}
 }


### PR DESCRIPTION
This PR introduces the following improvements and fixes:

Relocates the definition of the Carry report route:

The route for accessing the Carry report has been moved to a more appropriate place in the codebase, aligning with the project's structure and conventions. This change improves code organization and maintainability.

Adds missing validation for non-existent locations:

Before generating a Carry report for a specific locality, the system now verifies that the specified locality exists in the database. If the locality is not found, the API responds with an appropriate error. This enhances the robustness and user experience of the API by preventing reports on non-existent data.

Summary

With these changes, the routing structure is clarified and essential validation is added to prevent queries on unknown locations.
