### PR TITLE
fix: migration to new version of error handling

### DIFF
--- a/internal/handler/geography.go
+++ b/internal/handler/geography.go
@@ -57,7 +57,8 @@ func (h *GeographyHandler) CountSellersByLocality(w http.ResponseWriter, r *http
 
 	if id == "" {
 		resp, err := h.sv.CountSellersGroupedByLocality(ctx)
-		if handleApiError(w, err) {
+		if err != nil {
+			response.Error(w, err)
 			return
 		}
 		response.JSON(w, http.StatusOK, resp)
@@ -65,7 +66,8 @@ func (h *GeographyHandler) CountSellersByLocality(w http.ResponseWriter, r *http
 	}
 
 	s, err := h.sv.CountSellersByLocality(ctx, id)
-	if handleApiError(w, err) {
+	if err != nil {
+		response.Error(w, err)
 		return
 	}
 

--- a/internal/handler/section.go
+++ b/internal/handler/section.go
@@ -1,13 +1,14 @@
 package handler
 
 import (
+	"net/http"
+
 	"github.com/varobledo_meli/W17-G10-Bootcamp.git/internal/mappers"
 	"github.com/varobledo_meli/W17-G10-Bootcamp.git/internal/service"
 	"github.com/varobledo_meli/W17-G10-Bootcamp.git/internal/validators"
 	"github.com/varobledo_meli/W17-G10-Bootcamp.git/pkg/api/httputil"
 	"github.com/varobledo_meli/W17-G10-Bootcamp.git/pkg/api/response"
-	"github.com/varobledo_meli/W17-G10-Bootcamp.git/pkg/models/section"
-	"net/http"
+	models "github.com/varobledo_meli/W17-G10-Bootcamp.git/pkg/models/section"
 )
 
 // SectionDefault handles HTTP requests related to warehouse sections.
@@ -93,15 +94,16 @@ func (h *SectionDefault) CreateSection(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err1 := validators.ValidateSectionRequest(sectionReq)
-	if err1 != nil {
-		response.Error(w, err1)
+	err := validators.ValidateSectionRequest(sectionReq)
+	if err != nil {
+		response.Error(w, err)
 		return
 	}
 
 	sec := mappers.RequestSectionToSection(sectionReq)
-	newSection, err2 := h.sv.CreateSection(ctx, sec)
-	if handleApiError(w, err2) {
+	newSection, err := h.sv.CreateSection(ctx, sec)
+	if err != nil {
+		response.Error(w, err)
 		return
 	}
 

--- a/internal/handler/seller.go
+++ b/internal/handler/seller.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/varobledo_meli/W17-G10-Bootcamp.git/internal/service"
 	"github.com/varobledo_meli/W17-G10-Bootcamp.git/internal/validators"
-	"github.com/varobledo_meli/W17-G10-Bootcamp.git/pkg/api"
 	"github.com/varobledo_meli/W17-G10-Bootcamp.git/pkg/api/httputil"
 	"github.com/varobledo_meli/W17-G10-Bootcamp.git/pkg/api/response"
 	models "github.com/varobledo_meli/W17-G10-Bootcamp.git/pkg/models/seller"
@@ -139,21 +138,4 @@ func (h *SellerHandler) FindById(w http.ResponseWriter, r *http.Request) {
 	}
 
 	response.JSON(w, http.StatusOK, s)
-}
-
-func handleApiError(w http.ResponseWriter, err error) bool {
-	if err == nil {
-		return false
-	}
-	if errorResp, ok := err.(*api.ServiceError); ok {
-		// response.Error(w, errorResp.ResponseCode, errorResp.Message)
-		// response.Error(w, errorResp.ResponseCode, errorResp.Message)
-		response.Error(w, errorResp)
-	} else {
-		// response.Error(w, http.StatusInternalServerError, err.Error())
-		// response.Error(w, http.StatusInternalServerError, err.Error())
-		response.Error(w, err)
-	}
-
-	return true
 }


### PR DESCRIPTION
This Pull Request refactors error handling throughout the API handlers to align with the new error handling approach. The previous use of the helper function `handleApiError` has been removed, and error responses are now managed directly by checking for errors and returning them through `response.Error`. This results in cleaner and more consistent error handling logic in the handler files.

#### Key Changes:
- Removed the legacy `handleApiError` function from the codebase.
- Updated handler functions in `geography.go`, `section.go`, and `seller.go` to check for errors directly and call `response.Error` where appropriate.
- Cleaned up unused imports and redundant code after migration.

These changes make error handling more transparent and easier to follow across the codebase, improving maintainability and future extensibility.