### PR TITLE
feature: restruct of unit tests for employee for service and handler using testhelpers and added unit tests for inbound_order handler

### DIFF
--- a/internal/handler/employee/employee_update_test.go
+++ b/internal/handler/employee/employee_update_test.go
@@ -15,6 +15,7 @@ import (
 	employeeMocks "github.com/varobledo_meli/W17-G10-Bootcamp.git/mocks/employee"
 	"github.com/varobledo_meli/W17-G10-Bootcamp.git/pkg/api/apperrors"
 	models "github.com/varobledo_meli/W17-G10-Bootcamp.git/pkg/models/employee"
+	"github.com/varobledo_meli/W17-G10-Bootcamp.git/testhelpers"
 )
 
 func TestEmployeeHandler_Update(t *testing.T) {
@@ -28,25 +29,25 @@ func TestEmployeeHandler_Update(t *testing.T) {
 	}{
 		{
 			name: "update_ok",
-			id:   1,
+			id: func() int {
+				// Usamos el ID del helper para mantener consistencia
+				return testhelpers.CreateTestEmployee().ID // normalmente 1
+			}(),
 			patch: map[string]interface{}{
 				"first_name": "NombreActualizado",
 			},
+			// Devuelve un empleado modificado usando el helper como base
 			mockUpdateFn: func(ctx context.Context, id int, patch *models.EmployeePatch) (*models.Employee, error) {
-				return &models.Employee{
-					ID:           1,
-					CardNumberID: "E001",
-					FirstName:    "NombreActualizado",
-					LastName:     "Martinez",
-					WarehouseID:  1,
-				}, nil
+				e := testhelpers.CreateExpectedEmployee(id)
+				e.FirstName = "NombreActualizado"
+				return e, nil
 			},
 			wantStatus:  http.StatusOK,
 			wantContent: `"first_name":"NombreActualizado"`,
 		},
 		{
 			name: "update_non_existent",
-			id:   99,
+			id:   99, // Un id que no existe en los helpers
 			patch: map[string]interface{}{
 				"first_name": "NuevoNombre",
 			},
@@ -60,26 +61,30 @@ func TestEmployeeHandler_Update(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			// Configuramos el mock del service con el helper/func que queremos
 			mockSvc := &employeeMocks.EmployeeServiceMock{
 				MockUpdate: tc.mockUpdateFn,
 			}
 			h := handler.NewEmployeeHandler(mockSvc)
 
+			// Genera el body del PATCH como JSON usando lo que se va a actualizar
 			patchBody, _ := json.Marshal(tc.patch)
 			url := "/employees/" + strconv.Itoa(tc.id)
 			req := httptest.NewRequest("PATCH", url, bytes.NewReader(patchBody))
 			req.Header.Set("Content-Type", "application/json")
 			w := httptest.NewRecorder()
 
-			// Setup chi context param para el id
+			// Simula cómo chi pasaría los parámetros de ruta (id)
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("id", strconv.Itoa(tc.id))
 			req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 
+			// Ejecuta el handler PATCH
 			h.Update(w, req)
 			res := w.Result()
 			defer res.Body.Close()
 
+			// Chequea respuesta HTTP y contenido esperado
 			require.Equal(t, tc.wantStatus, res.StatusCode)
 			require.Contains(t, w.Body.String(), tc.wantContent)
 		})

--- a/internal/handler/inbound_order/inbound_order_create_test.go
+++ b/internal/handler/inbound_order/inbound_order_create_test.go
@@ -1,0 +1,82 @@
+package handler_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	handler "github.com/varobledo_meli/W17-G10-Bootcamp.git/internal/handler/inbound_order"
+	inboundOrderMocks "github.com/varobledo_meli/W17-G10-Bootcamp.git/mocks/inbound_order"
+	"github.com/varobledo_meli/W17-G10-Bootcamp.git/pkg/api/apperrors"
+	models "github.com/varobledo_meli/W17-G10-Bootcamp.git/pkg/models/inbound_order"
+	"github.com/varobledo_meli/W17-G10-Bootcamp.git/testhelpers"
+)
+
+func TestInboundOrderHandler_Create(t *testing.T) {
+	testCases := []struct {
+		name         string
+		payload      map[string]interface{}
+		mockCreateFn func(ctx context.Context, in *models.InboundOrder) (*models.InboundOrder, error)
+		wantStatus   int
+		wantContent  string
+	}{
+		{
+			name: "create_ok",
+			// Armamos el payload usando el helper para DRY y centralización de datos base
+			payload: func() map[string]interface{} {
+				ord := testhelpers.CreateTestInboundOrder()
+				return map[string]interface{}{
+					"order_number":     ord.OrderNumber,
+					"order_date":       ord.OrderDate,
+					"employee_id":      ord.EmployeeID,
+					"product_batch_id": ord.ProductBatchID,
+					"warehouse_id":     ord.WarehouseID,
+				}
+			}(),
+			// El mock simula creación exitosa y devuelve un order con ID esperando en respuesta
+			mockCreateFn: func(ctx context.Context, in *models.InboundOrder) (*models.InboundOrder, error) {
+				o := testhelpers.CreateExpectedInboundOrder(22)
+				return o, nil
+			},
+			wantStatus:  http.StatusCreated,
+			wantContent: `"order_number":"INV001"`,
+		},
+		{
+			name: "create_validation_error",
+			// Payload incompleto: simulando JSON inválido (muestra cómo sería válido el helper)
+			payload: map[string]interface{}{
+				// Faltan campos importantes
+				"order_number": "",
+			},
+			mockCreateFn: func(ctx context.Context, in *models.InboundOrder) (*models.InboundOrder, error) {
+				return nil, apperrors.NewAppError(apperrors.CodeValidationError, "invalid inbound_order")
+			},
+			wantStatus:  http.StatusUnprocessableEntity,
+			wantContent: `"invalid inbound_order"`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Inyectamos el mock del servicio en el handler
+			mockSvc := &inboundOrderMocks.InboundOrderServiceMock{MockCreate: tc.mockCreateFn}
+			h := handler.NewInboundOrderHandler(mockSvc)
+			// Marshal el payload en el formato recibido por el handler
+			body, _ := json.Marshal(map[string]interface{}{"data": tc.payload})
+			req := httptest.NewRequest("POST", "/api/v1/inboundOrders", bytes.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			// Ejecutamos el handler
+			h.Create(w, req)
+			res := w.Result()
+			defer res.Body.Close()
+			// Verifica status y presencia de contenido esperado en la respuesta
+			require.Equal(t, tc.wantStatus, res.StatusCode)
+			require.Contains(t, w.Body.String(), tc.wantContent)
+		})
+	}
+}

--- a/internal/handler/inbound_order/inbound_order_read_test.go
+++ b/internal/handler/inbound_order/inbound_order_read_test.go
@@ -1,0 +1,80 @@
+package handler_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	handler "github.com/varobledo_meli/W17-G10-Bootcamp.git/internal/handler/inbound_order"
+	inboundOrderMocks "github.com/varobledo_meli/W17-G10-Bootcamp.git/mocks/inbound_order"
+	"github.com/varobledo_meli/W17-G10-Bootcamp.git/pkg/api/apperrors"
+	models "github.com/varobledo_meli/W17-G10-Bootcamp.git/pkg/models/inbound_order"
+	"github.com/varobledo_meli/W17-G10-Bootcamp.git/testhelpers"
+)
+
+// Test para GET /api/v1/employees/reportInboundOrders con distintos escenarios usando helpers/mocks
+func TestInboundOrderHandler_Report(t *testing.T) {
+	testCases := []struct {
+		name        string
+		queryID     *int
+		mockReport  func(ctx context.Context, id *int) (interface{}, error)
+		wantStatus  int
+		wantContent string
+	}{
+		{
+			name:    "report_ok",
+			queryID: func() *int { i := 1; return &i }(), // Simula llamado con ?id=1
+			mockReport: func(ctx context.Context, id *int) (interface{}, error) {
+				// Devuelve el slice de reportes como interface{}
+				return testhelpers.CreateInboundOrderReports(), nil
+			},
+			wantStatus:  http.StatusOK,
+			wantContent: `"inbound_orders_count":5`, // Espera campo correcto en JSON
+		},
+		{
+			name:    "report_empty",
+			queryID: nil, // Simula llamado SIN id param (?id=)
+			// Devuelve un slice vacío (indicando ningún reporte)
+			mockReport: func(ctx context.Context, id *int) (interface{}, error) {
+				return []models.InboundOrderReport{}, nil
+			},
+			wantStatus:  http.StatusOK,
+			wantContent: `"data":[]`, // JSON esperado para lista vacía
+		},
+		{
+			name:    "report_not_found",
+			queryID: func() *int { i := 999; return &i }(), // id que no existe
+			mockReport: func(ctx context.Context, id *int) (interface{}, error) {
+				// Simula error not found
+				return nil, apperrors.NewAppError(apperrors.CodeNotFound, "not found")
+			},
+			wantStatus:  http.StatusNotFound,
+			wantContent: `"not found"`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Mock de servicio usando el closure de la tabla de test
+			mockSvc := &inboundOrderMocks.InboundOrderServiceMock{MockReport: tc.mockReport}
+			h := handler.NewInboundOrderHandler(mockSvc)
+			// Construye la URL con o sin query param según el caso
+			url := "/api/v1/employees/reportInboundOrders"
+			if tc.queryID != nil {
+				url += "?id=" + strconv.Itoa(*tc.queryID)
+			}
+			req := httptest.NewRequest("GET", url, nil)
+			w := httptest.NewRecorder()
+			// Ejecuta el handler directamente
+			h.Report(w, req)
+			res := w.Result()
+			defer res.Body.Close()
+			// Validamos status y parte de la respuesta deseada
+			require.Equal(t, tc.wantStatus, res.StatusCode)
+			require.Contains(t, w.Body.String(), tc.wantContent)
+		})
+	}
+}

--- a/internal/service/employee/employee_create_test.go
+++ b/internal/service/employee/employee_create_test.go
@@ -25,23 +25,26 @@ func TestEmployeeService_Create(t *testing.T) {
 		{
 			name: "create_ok",
 			repoMock: func() *employeeMocks.EmployeeRepositoryMock {
+				// Mock del repositorio: simula que el cardNumberID NO existe y luego crea el empleado
 				return &employeeMocks.EmployeeRepositoryMock{
 					MockFindByCardNumberID: func(ctx context.Context, cardNumberID string) (*models.Employee, error) {
 						return nil, nil
 					},
 					MockCreate: func(ctx context.Context, e *models.Employee) (*models.Employee, error) {
-						e.ID = 1
+						e.ID = 1 // simula el autoincremento de la db
 						return e, nil
 					},
 				}
 			},
 			warehouseMock: func() *warehouseMocks.WarehouseRepositoryMock {
+				// Simula que el warehouse existe
 				return &warehouseMocks.WarehouseRepositoryMock{
 					FuncFindById: func(ctx context.Context, id int) (*wmodels.Warehouse, error) {
 						return &wmodels.Warehouse{Id: id}, nil // Warehouse existe
 					},
 				}
 			},
+			// Usamos el helper, solo sobrescribiendo los valores relevantes para este test
 			input: func() *models.Employee {
 				e := testhelpers.CreateTestEmployee()
 				// Setea los valores deseados para el test:
@@ -56,6 +59,7 @@ func TestEmployeeService_Create(t *testing.T) {
 		{
 			name: "create_conflict",
 			repoMock: func() *employeeMocks.EmployeeRepositoryMock {
+				// Simula que el cardNumberID YA existe, así que Create nunca es invocado
 				return &employeeMocks.EmployeeRepositoryMock{
 					MockFindByCardNumberID: func(ctx context.Context, cardNumberID string) (*models.Employee, error) {
 						return &models.Employee{ID: 99, CardNumberID: cardNumberID}, nil
@@ -72,6 +76,7 @@ func TestEmployeeService_Create(t *testing.T) {
 					},
 				}
 			},
+			// Usamos de nuevo el helper, cambiando solo los valores relevantes para este caso
 			input: func() *models.Employee {
 				e := testhelpers.CreateTestEmployee()
 				e.CardNumberID = "E001"
@@ -86,17 +91,20 @@ func TestEmployeeService_Create(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			// Instancia los mocks para repo y warehouse según el caso
 			emRepo := tc.repoMock()
 			whRepo := tc.warehouseMock()
 			svc := service.NewEmployeeDefault(emRepo, whRepo)
-
+			// Ejecuta el método Create del service con el input armado con helper
 			res, err := svc.Create(context.Background(), tc.input)
 
 			if tc.wantErrCode == "" {
+				// Caso de éxito: no hay error, el empleado creado debe coincidir con el input
 				require.NoError(t, err)
 				require.NotNil(t, res)
 				require.Equal(t, tc.input.CardNumberID, res.CardNumberID)
 			} else {
+				// Caso de conflicto: debe retornar error del tipo esperado
 				require.Error(t, err)
 				appErr, ok := err.(*apperrors.AppError)
 				require.True(t, ok)

--- a/internal/service/employee/employee_create_test.go
+++ b/internal/service/employee/employee_create_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/varobledo_meli/W17-G10-Bootcamp.git/pkg/api/apperrors"
 	models "github.com/varobledo_meli/W17-G10-Bootcamp.git/pkg/models/employee"
 	wmodels "github.com/varobledo_meli/W17-G10-Bootcamp.git/pkg/models/warehouse"
+	"github.com/varobledo_meli/W17-G10-Bootcamp.git/testhelpers"
 )
 
 func TestEmployeeService_Create(t *testing.T) {
@@ -41,12 +42,15 @@ func TestEmployeeService_Create(t *testing.T) {
 					},
 				}
 			},
-			input: &models.Employee{
-				CardNumberID: "E001",
-				FirstName:    "Paola",
-				LastName:     "Lopez",
-				WarehouseID:  1,
-			},
+			input: func() *models.Employee {
+				e := testhelpers.CreateTestEmployee()
+				// Setea los valores deseados para el test:
+				e.CardNumberID = "E001"
+				e.FirstName = "Paola"
+				e.LastName = "Lopez"
+				e.WarehouseID = 1
+				return &e
+			}(),
 			wantErrCode: "",
 		},
 		{
@@ -68,12 +72,14 @@ func TestEmployeeService_Create(t *testing.T) {
 					},
 				}
 			},
-			input: &models.Employee{
-				CardNumberID: "E001",
-				FirstName:    "Lucia",
-				LastName:     "Soler",
-				WarehouseID:  1,
-			},
+			input: func() *models.Employee {
+				e := testhelpers.CreateTestEmployee()
+				e.CardNumberID = "E001"
+				e.FirstName = "Lucia"
+				e.LastName = "Soler"
+				e.WarehouseID = 1
+				return &e
+			}(),
 			wantErrCode: apperrors.CodeConflict,
 		},
 	}
@@ -95,121 +101,6 @@ func TestEmployeeService_Create(t *testing.T) {
 				appErr, ok := err.(*apperrors.AppError)
 				require.True(t, ok)
 				require.Equal(t, tc.wantErrCode, appErr.Code)
-			}
-		})
-	}
-}
-
-func TestEmployeeService_Create_extraCases(t *testing.T) {
-	testCases := []struct {
-		name        string
-		input       *models.Employee
-		repoMock    func() *employeeMocks.EmployeeRepositoryMock
-		whMock      func() *warehouseMocks.WarehouseRepositoryMock
-		wantErrCode string // "" si se espera success
-		checkWrap   string // mensaje si se espera error envuelto
-	}{
-		{
-			name:  "validation_error",
-			input: &models.Employee{},
-			repoMock: func() *employeeMocks.EmployeeRepositoryMock {
-				return &employeeMocks.EmployeeRepositoryMock{}
-			},
-			whMock: func() *warehouseMocks.WarehouseRepositoryMock { // won't be called
-				return &warehouseMocks.WarehouseRepositoryMock{}
-			},
-			wantErrCode: apperrors.CodeValidationError,
-		},
-		{
-			name: "warehouse find generic error",
-			input: &models.Employee{
-				CardNumberID: "X", FirstName: "A", LastName: "B", WarehouseID: 1,
-			},
-			repoMock: func() *employeeMocks.EmployeeRepositoryMock {
-				return &employeeMocks.EmployeeRepositoryMock{}
-			},
-			whMock: func() *warehouseMocks.WarehouseRepositoryMock {
-				return &warehouseMocks.WarehouseRepositoryMock{
-					FuncFindById: func(ctx context.Context, id int) (*wmodels.Warehouse, error) {
-						return nil, context.DeadlineExceeded
-					},
-				}
-			},
-			checkWrap: "failed getting warehouse by id",
-		},
-		{
-			name: "warehouse not exists (not found code)",
-			input: &models.Employee{
-				CardNumberID: "X", FirstName: "A", LastName: "B", WarehouseID: 1,
-			},
-			repoMock: func() *employeeMocks.EmployeeRepositoryMock {
-				return &employeeMocks.EmployeeRepositoryMock{}
-			},
-			whMock: func() *warehouseMocks.WarehouseRepositoryMock {
-				return &warehouseMocks.WarehouseRepositoryMock{
-					FuncFindById: func(ctx context.Context, id int) (*wmodels.Warehouse, error) {
-						return nil, apperrors.NewAppError(apperrors.CodeNotFound, "no warehouse")
-					},
-				}
-			},
-			wantErrCode: apperrors.CodeBadRequest,
-		},
-		{
-			name: "warehouse nil, no error",
-			input: &models.Employee{
-				CardNumberID: "X", FirstName: "A", LastName: "B", WarehouseID: 1,
-			},
-			repoMock: func() *employeeMocks.EmployeeRepositoryMock {
-				return &employeeMocks.EmployeeRepositoryMock{}
-			},
-			whMock: func() *warehouseMocks.WarehouseRepositoryMock {
-				return &warehouseMocks.WarehouseRepositoryMock{
-					FuncFindById: func(ctx context.Context, id int) (*wmodels.Warehouse, error) {
-						return nil, nil
-					},
-				}
-			},
-			wantErrCode: apperrors.CodeBadRequest,
-		},
-		{
-			name: "findByCardNumberID returns err (generic)",
-			input: &models.Employee{
-				CardNumberID: "X", FirstName: "A", LastName: "B", WarehouseID: 1,
-			},
-			repoMock: func() *employeeMocks.EmployeeRepositoryMock {
-				return &employeeMocks.EmployeeRepositoryMock{
-					MockFindByCardNumberID: func(ctx context.Context, cardNumberID string) (*models.Employee, error) {
-						return nil, context.DeadlineExceeded
-					},
-				}
-			},
-			whMock: func() *warehouseMocks.WarehouseRepositoryMock {
-				return &warehouseMocks.WarehouseRepositoryMock{
-					FuncFindById: func(ctx context.Context, id int) (*wmodels.Warehouse, error) {
-						return &wmodels.Warehouse{Id: 1}, nil
-					},
-				}
-			},
-			checkWrap: "failed checking card_number_id",
-		},
-	}
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			svc := service.NewEmployeeDefault(tc.repoMock(), tc.whMock())
-			res, err := svc.Create(context.Background(), tc.input)
-			if tc.wantErrCode != "" {
-				require.Error(t, err)
-				appErr, ok := err.(*apperrors.AppError)
-				require.True(t, ok)
-				require.Equal(t, tc.wantErrCode, appErr.Code)
-				require.Nil(t, res)
-			} else if tc.checkWrap != "" {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), tc.checkWrap)
-				require.Nil(t, res)
-			} else {
-				require.NoError(t, err)
-				require.NotNil(t, res)
 			}
 		})
 	}

--- a/internal/service/employee/employee_delete_test.go
+++ b/internal/service/employee/employee_delete_test.go
@@ -10,6 +10,7 @@ import (
 	warehouseMocks "github.com/varobledo_meli/W17-G10-Bootcamp.git/mocks/warehouse"
 	"github.com/varobledo_meli/W17-G10-Bootcamp.git/pkg/api/apperrors"
 	models "github.com/varobledo_meli/W17-G10-Bootcamp.git/pkg/models/employee"
+	"github.com/varobledo_meli/W17-G10-Bootcamp.git/testhelpers"
 )
 
 func TestEmployeeService_Delete(t *testing.T) {
@@ -25,7 +26,10 @@ func TestEmployeeService_Delete(t *testing.T) {
 			repoMock: func() *employeeMocks.EmployeeRepositoryMock {
 				return &employeeMocks.EmployeeRepositoryMock{
 					MockFindByID: func(ctx context.Context, id int) (*models.Employee, error) {
-						return &models.Employee{ID: id, CardNumberID: "E005"}, nil
+						e := testhelpers.CreateTestEmployee()
+						e.ID = id
+						e.CardNumberID = "E005"
+						return &e, nil
 					},
 					MockDelete: func(ctx context.Context, id int) error {
 						return nil

--- a/internal/service/employee/employee_read_test.go
+++ b/internal/service/employee/employee_read_test.go
@@ -10,6 +10,7 @@ import (
 	warehouseMocks "github.com/varobledo_meli/W17-G10-Bootcamp.git/mocks/warehouse"
 	"github.com/varobledo_meli/W17-G10-Bootcamp.git/pkg/api/apperrors"
 	models "github.com/varobledo_meli/W17-G10-Bootcamp.git/pkg/models/employee"
+	"github.com/varobledo_meli/W17-G10-Bootcamp.git/testhelpers"
 )
 
 func TestEmployeeService_Read(t *testing.T) {
@@ -17,21 +18,23 @@ func TestEmployeeService_Read(t *testing.T) {
 		name        string
 		repoMock    func() *employeeMocks.EmployeeRepositoryMock
 		findAll     bool
-		inputID     int // para find_by_id casos
+		inputID     int
 		wantErr     bool
 		wantErrCode string
-		wantLen     int // Para find_all caso feliz
-		wantID      int // Para find_by_id_existente
+		wantLen     int
+		wantID      int
 	}{
 		{
 			name: "find_all",
 			repoMock: func() *employeeMocks.EmployeeRepositoryMock {
+				emps := testhelpers.CreateTestEmployees()
+				var empsPtrs []*models.Employee
+				for i := range emps {
+					empsPtrs = append(empsPtrs, &emps[i])
+				}
 				return &employeeMocks.EmployeeRepositoryMock{
 					MockFindAll: func(ctx context.Context) ([]*models.Employee, error) {
-						return []*models.Employee{
-							{ID: 1, CardNumberID: "E001", FirstName: "Lucas", LastName: "Martinez", WarehouseID: 1},
-							{ID: 2, CardNumberID: "E002", FirstName: "Sonia", LastName: "Lopez", WarehouseID: 2},
-						}, nil
+						return empsPtrs, nil
 					},
 				}
 			},
@@ -58,9 +61,7 @@ func TestEmployeeService_Read(t *testing.T) {
 			repoMock: func() *employeeMocks.EmployeeRepositoryMock {
 				return &employeeMocks.EmployeeRepositoryMock{
 					MockFindByID: func(ctx context.Context, id int) (*models.Employee, error) {
-						return &models.Employee{
-							ID: id, CardNumberID: "E015", FirstName: "Maria", LastName: "Perez", WarehouseID: 3,
-						}, nil
+						return testhelpers.CreateExpectedEmployee(id), nil
 					},
 				}
 			},
@@ -89,102 +90,11 @@ func TestEmployeeService_Read(t *testing.T) {
 					appErr, ok := err.(*apperrors.AppError)
 					require.True(t, ok)
 					require.Equal(t, tc.wantErrCode, appErr.Code)
+					require.Nil(t, res)
 				} else {
 					require.NoError(t, err)
 					require.NotNil(t, res)
 					require.Equal(t, tc.wantID, res.ID)
-				}
-			}
-		})
-	}
-}
-
-func TestEmployeeService_Read_extraCases(t *testing.T) {
-	testCases := []struct {
-		name        string
-		id          int
-		findAll     bool
-		repoMock    func() *employeeMocks.EmployeeRepositoryMock
-		wantErrCode string
-		checkWrap   string
-	}{
-		{
-			name: "invalid id for FindByID",
-			id:   0,
-			repoMock: func() *employeeMocks.EmployeeRepositoryMock {
-				return &employeeMocks.EmployeeRepositoryMock{
-					MockFindByID: func(ctx context.Context, id int) (*models.Employee, error) { return nil, nil },
-				}
-			},
-			wantErrCode: apperrors.CodeValidationError,
-		},
-		{
-			name: "repo.FindByID returns error",
-			id:   5,
-			repoMock: func() *employeeMocks.EmployeeRepositoryMock {
-				return &employeeMocks.EmployeeRepositoryMock{
-					MockFindByID: func(ctx context.Context, id int) (*models.Employee, error) { return nil, context.Canceled },
-				}
-			},
-			checkWrap: "failed fetching employee by id",
-		},
-		{
-			name: "repo.FindByID returns nil, nil",
-			id:   15,
-			repoMock: func() *employeeMocks.EmployeeRepositoryMock {
-				return &employeeMocks.EmployeeRepositoryMock{
-					MockFindByID: func(ctx context.Context, id int) (*models.Employee, error) { return nil, nil },
-				}
-			},
-			wantErrCode: apperrors.CodeNotFound,
-		},
-		{
-			name:    "repo.FindAll returns error",
-			findAll: true,
-			repoMock: func() *employeeMocks.EmployeeRepositoryMock {
-				return &employeeMocks.EmployeeRepositoryMock{
-					MockFindAll: func(ctx context.Context) ([]*models.Employee, error) { return nil, context.DeadlineExceeded },
-				}
-			},
-			checkWrap: "failed fetching all employees",
-		},
-	}
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			emRepo := tc.repoMock()
-			whRepo := &warehouseMocks.WarehouseRepositoryMock{}
-			svc := service.NewEmployeeDefault(emRepo, whRepo)
-			if tc.findAll {
-				res, err := svc.FindAll(context.Background())
-				if tc.wantErrCode != "" {
-					require.Error(t, err)
-					appErr, ok := err.(*apperrors.AppError)
-					require.True(t, ok)
-					require.Equal(t, tc.wantErrCode, appErr.Code)
-					require.Nil(t, res)
-				} else if tc.checkWrap != "" {
-					require.Error(t, err)
-					require.Contains(t, err.Error(), tc.checkWrap)
-					require.Nil(t, res)
-				} else {
-					require.NoError(t, err)
-					require.NotNil(t, res)
-				}
-			} else {
-				res, err := svc.FindByID(context.Background(), tc.id)
-				if tc.wantErrCode != "" {
-					require.Error(t, err)
-					appErr, ok := err.(*apperrors.AppError)
-					require.True(t, ok)
-					require.Equal(t, tc.wantErrCode, appErr.Code)
-					require.Nil(t, res)
-				} else if tc.checkWrap != "" {
-					require.Error(t, err)
-					require.Contains(t, err.Error(), tc.checkWrap)
-					require.Nil(t, res)
-				} else {
-					require.NoError(t, err)
-					require.NotNil(t, res)
 				}
 			}
 		})

--- a/internal/service/employee/employee_update_test.go
+++ b/internal/service/employee/employee_update_test.go
@@ -16,6 +16,7 @@ import (
 
 func strPtr(s string) *string { return &s }
 
+// Tests actualización de empleados usando helpers para DRY y centralización de datos.
 func TestEmployeeService_Update(t *testing.T) {
 	testCases := []struct {
 		name          string
@@ -33,12 +34,14 @@ func TestEmployeeService_Update(t *testing.T) {
 				base := testhelpers.CreateTestEmployee()
 				updatedFirstName := base.FirstName
 				return &employeeMocks.EmployeeRepositoryMock{
+					// Simula que el empleado existe antes del update
 					MockFindByID: func(ctx context.Context, id int) (*models.Employee, error) {
 						emp := base
 						emp.ID = id
 						emp.FirstName = updatedFirstName
 						return &emp, nil
 					},
+					// Simula que el cambio de nombre se guarda
 					MockUpdate: func(ctx context.Context, id int, e *models.Employee) error {
 						updatedFirstName = e.FirstName // Simula persistir el cambio
 						return nil
@@ -53,6 +56,7 @@ func TestEmployeeService_Update(t *testing.T) {
 		{
 			name: "update_non_existent",
 			repoMock: func() *employeeMocks.EmployeeRepositoryMock {
+				// Simula que el empleado no existe (devuelve nil y error)
 				return &employeeMocks.EmployeeRepositoryMock{
 					MockFindByID: func(ctx context.Context, id int) (*models.Employee, error) {
 						return nil, apperrors.NewAppError(apperrors.CodeNotFound, "employee not found")
@@ -71,18 +75,21 @@ func TestEmployeeService_Update(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			// Instanciar los mocks del repositorio y warehouse
 			emRepo := tc.repoMock()
 			whRepo := &warehouseMocks.WarehouseRepositoryMock{}
 			svc := service.NewEmployeeDefault(emRepo, whRepo)
-
+			// Ejecutar el update
 			res, err := svc.Update(context.Background(), tc.inputID, tc.patch)
 			if tc.wantErr {
+				// Caso de error esperado: debe ser del tipo/código correcto y resultado nulo
 				require.Error(t, err)
 				appErr, ok := err.(*apperrors.AppError)
 				require.True(t, ok)
 				require.Equal(t, tc.wantErrCode, appErr.Code)
 				require.Nil(t, res)
 			} else {
+				// Caso exitoso: no error, resultado no nulo y nombre actualizado
 				require.NoError(t, err)
 				require.NotNil(t, res)
 				if tc.wantFirstName != "" && res.FirstName != tc.wantFirstName {

--- a/mocks/inbound_order/inbound_order_service_mock.go
+++ b/mocks/inbound_order/inbound_order_service_mock.go
@@ -1,0 +1,20 @@
+package mocks
+
+import (
+	"context"
+
+	models "github.com/varobledo_meli/W17-G10-Bootcamp.git/pkg/models/inbound_order"
+)
+
+// Interfaz de service
+type InboundOrderServiceMock struct {
+	MockCreate func(ctx context.Context, in *models.InboundOrder) (*models.InboundOrder, error)
+	MockReport func(ctx context.Context, id *int) (interface{}, error)
+}
+
+func (m *InboundOrderServiceMock) Create(ctx context.Context, in *models.InboundOrder) (*models.InboundOrder, error) {
+	return m.MockCreate(ctx, in)
+}
+func (m *InboundOrderServiceMock) Report(ctx context.Context, id *int) (interface{}, error) {
+	return m.MockReport(ctx, id)
+}

--- a/testhelpers/inbound_order.go
+++ b/testhelpers/inbound_order.go
@@ -1,0 +1,40 @@
+package testhelpers
+
+import (
+	models "github.com/varobledo_meli/W17-G10-Bootcamp.git/pkg/models/inbound_order"
+)
+
+// Devuelve un inbound_order típico
+func CreateTestInboundOrder() models.InboundOrder {
+	return models.InboundOrder{
+		OrderNumber:    "INV001",
+		OrderDate:      "2024-06-01",
+		EmployeeID:     1,
+		ProductBatchID: 10,
+		WarehouseID:    1,
+	}
+}
+
+func CreateExpectedInboundOrder(id int) *models.InboundOrder {
+	o := CreateTestInboundOrder()
+	o.ID = id
+	return &o
+}
+
+func CreateInboundOrderReport(id int) models.InboundOrderReport {
+	return models.InboundOrderReport{
+		ID:                 id,
+		CardNumberID:       "CARDID",
+		FirstName:          "Juan",
+		LastName:           "Tester",
+		WarehouseID:        1,
+		InboundOrdersCount: 5,
+	}
+}
+
+func CreateInboundOrderReports() []models.InboundOrderReport {
+	return []models.InboundOrderReport{
+		CreateInboundOrderReport(1),
+		CreateInboundOrderReport(2),
+	}
+}


### PR DESCRIPTION
**Descripción**

- Se agregaron tests unitarios para el handler de inbound_order, cubriendo los endpoints de creación (POST) y reporte (GET).
- Estos tests utilizan helpers centralizados (testhelpers) para generar datos dummy de inbound orders, garantizando coherencia en los escenarios de prueba.
- Además, se implementó un mock del service de inbound_order para desacoplar la lógica del handler y simular distintos resultados y errores controladamente.

**Refactor de tests de employee**

- Se refactorizaron los tests del handler y del service de employee para aprovechar los helpers de datos (testhelpers) de empleados.
- Ahora todos los tests de employee (handler y service) usan datos dummy centralizados en helpers, mejorando la mantenibilidad, claridad y eliminando duplicidad de setup en los casos de prueba.