### PR TITLE
feature: added unit testings for inbound_order service using inbound_order repo mock and helpers in testhelpers

### DIFF
--- a/internal/service/inbound_order/inbound_order_create_test.go
+++ b/internal/service/inbound_order/inbound_order_create_test.go
@@ -1,0 +1,278 @@
+package service_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	service "github.com/varobledo_meli/W17-G10-Bootcamp.git/internal/service/inbound_order"
+	employeeMocks "github.com/varobledo_meli/W17-G10-Bootcamp.git/mocks/employee"
+	inboundOrderMocks "github.com/varobledo_meli/W17-G10-Bootcamp.git/mocks/inbound_order"
+	warehouseMocks "github.com/varobledo_meli/W17-G10-Bootcamp.git/mocks/warehouse"
+	"github.com/varobledo_meli/W17-G10-Bootcamp.git/pkg/api/apperrors"
+	employeeModels "github.com/varobledo_meli/W17-G10-Bootcamp.git/pkg/models/employee"
+	models "github.com/varobledo_meli/W17-G10-Bootcamp.git/pkg/models/inbound_order"
+	warehouseModels "github.com/varobledo_meli/W17-G10-Bootcamp.git/pkg/models/warehouse"
+	"github.com/varobledo_meli/W17-G10-Bootcamp.git/testhelpers"
+)
+
+func TestInboundOrderService_Create(t *testing.T) {
+	testCases := []struct {
+		name          string
+		repoMock      func() *inboundOrderMocks.InboundOrderRepositoryMock
+		employeeMock  func() *employeeMocks.EmployeeRepositoryMock
+		warehouseMock func() *warehouseMocks.WarehouseRepositoryMock
+		input         *models.InboundOrder
+		wantErrCode   string
+	}{
+		{
+			name: "create_ok",
+			// Todos los pasos de validación pasan, el create es exitoso.
+			repoMock: func() *inboundOrderMocks.InboundOrderRepositoryMock {
+				return &inboundOrderMocks.InboundOrderRepositoryMock{
+					MockExistsByOrderNumber: func(ctx context.Context, orderNumber string) (bool, error) {
+						return false, nil
+					},
+					MockCreate: func(ctx context.Context, o *models.InboundOrder) (*models.InboundOrder, error) {
+						o.ID = 1
+						return o, nil
+					},
+				}
+			},
+			employeeMock: func() *employeeMocks.EmployeeRepositoryMock {
+				return &employeeMocks.EmployeeRepositoryMock{
+					MockFindByID: func(ctx context.Context, id int) (*employeeModels.Employee, error) {
+						e := testhelpers.CreateTestEmployee()
+						e.ID = id
+						return &e, nil
+					},
+				}
+			},
+			warehouseMock: func() *warehouseMocks.WarehouseRepositoryMock {
+				return &warehouseMocks.WarehouseRepositoryMock{
+					FuncFindById: func(ctx context.Context, id int) (*warehouseModels.Warehouse, error) {
+						return &warehouseModels.Warehouse{Id: id}, nil
+					},
+				}
+			},
+			input:       testhelpers.CreateExpectedInboundOrder(0),
+			wantErrCode: "", // Éxito
+		},
+		{
+			name: "order_number_conflict",
+			// El número de orden YA existe, el service debe devolver conflicto.
+			repoMock: func() *inboundOrderMocks.InboundOrderRepositoryMock {
+				return &inboundOrderMocks.InboundOrderRepositoryMock{
+					MockExistsByOrderNumber: func(ctx context.Context, orderNumber string) (bool, error) {
+						return true, nil
+					},
+					MockCreate: func(ctx context.Context, o *models.InboundOrder) (*models.InboundOrder, error) {
+						return nil, apperrors.NewAppError(apperrors.CodeConflict, "order_number already exists")
+					},
+				}
+			},
+			employeeMock:  func() *employeeMocks.EmployeeRepositoryMock { return &employeeMocks.EmployeeRepositoryMock{} },
+			warehouseMock: func() *warehouseMocks.WarehouseRepositoryMock { return &warehouseMocks.WarehouseRepositoryMock{} },
+			input:         testhelpers.CreateExpectedInboundOrder(0),
+			wantErrCode:   apperrors.CodeConflict,
+		},
+		{
+			name: "validation_error",
+			// Falla la validación de campos requeridos
+			repoMock: func() *inboundOrderMocks.InboundOrderRepositoryMock {
+				return &inboundOrderMocks.InboundOrderRepositoryMock{}
+			},
+			employeeMock:  func() *employeeMocks.EmployeeRepositoryMock { return &employeeMocks.EmployeeRepositoryMock{} },
+			warehouseMock: func() *warehouseMocks.WarehouseRepositoryMock { return &warehouseMocks.WarehouseRepositoryMock{} },
+			input:         &models.InboundOrder{}, // Input vacío
+			wantErrCode:   "VALIDATION_ERROR",
+		},
+		{
+			name: "exists check error",
+			// Error al consultar repositorio para unicidad
+			repoMock: func() *inboundOrderMocks.InboundOrderRepositoryMock {
+				return &inboundOrderMocks.InboundOrderRepositoryMock{
+					MockExistsByOrderNumber: func(ctx context.Context, orderNumber string) (bool, error) {
+						return false, apperrors.NewAppError("INTERNAL", "db down")
+					},
+				}
+			},
+			employeeMock:  func() *employeeMocks.EmployeeRepositoryMock { return &employeeMocks.EmployeeRepositoryMock{} },
+			warehouseMock: func() *warehouseMocks.WarehouseRepositoryMock { return &warehouseMocks.WarehouseRepositoryMock{} },
+			input:         testhelpers.CreateExpectedInboundOrder(0),
+			wantErrCode:   "INTERNAL",
+		},
+		{
+			name: "employee_repo error",
+			// Falla el repositorio de empleados al buscar empleado
+			repoMock: func() *inboundOrderMocks.InboundOrderRepositoryMock {
+				return &inboundOrderMocks.InboundOrderRepositoryMock{
+					MockExistsByOrderNumber: func(ctx context.Context, orderNumber string) (bool, error) { return false, nil },
+				}
+			},
+			employeeMock: func() *employeeMocks.EmployeeRepositoryMock {
+				return &employeeMocks.EmployeeRepositoryMock{
+					MockFindByID: func(ctx context.Context, id int) (*employeeModels.Employee, error) {
+						return nil, apperrors.NewAppError("INTERNAL", "fail")
+					},
+				}
+			},
+			warehouseMock: func() *warehouseMocks.WarehouseRepositoryMock {
+				return &warehouseMocks.WarehouseRepositoryMock{}
+			},
+			input:       testhelpers.CreateExpectedInboundOrder(0),
+			wantErrCode: "INTERNAL",
+		},
+		{
+			name: "employee not found",
+			// El empleado referenciado no existe
+			repoMock: func() *inboundOrderMocks.InboundOrderRepositoryMock {
+				return &inboundOrderMocks.InboundOrderRepositoryMock{
+					MockExistsByOrderNumber: func(ctx context.Context, orderNumber string) (bool, error) { return false, nil },
+				}
+			},
+			employeeMock: func() *employeeMocks.EmployeeRepositoryMock {
+				return &employeeMocks.EmployeeRepositoryMock{
+					MockFindByID: func(ctx context.Context, id int) (*employeeModels.Employee, error) { return nil, nil },
+				}
+			},
+			warehouseMock: func() *warehouseMocks.WarehouseRepositoryMock {
+				return &warehouseMocks.WarehouseRepositoryMock{}
+			},
+			input:       testhelpers.CreateExpectedInboundOrder(0),
+			wantErrCode: "CONFLICT",
+		},
+		{
+			name: "warehouse find error",
+			// Falla la consulta a bodega (warehouse) desde el repo de warehouse (error sql)
+			repoMock: func() *inboundOrderMocks.InboundOrderRepositoryMock {
+				return &inboundOrderMocks.InboundOrderRepositoryMock{
+					MockExistsByOrderNumber: func(ctx context.Context, orderNumber string) (bool, error) { return false, nil },
+				}
+			},
+			employeeMock: func() *employeeMocks.EmployeeRepositoryMock {
+				return &employeeMocks.EmployeeRepositoryMock{
+					MockFindByID: func(ctx context.Context, id int) (*employeeModels.Employee, error) {
+						e := testhelpers.CreateTestEmployee()
+						e.ID = id
+						return &e, nil
+					},
+				}
+			},
+			warehouseMock: func() *warehouseMocks.WarehouseRepositoryMock {
+				return &warehouseMocks.WarehouseRepositoryMock{
+					FuncFindById: func(ctx context.Context, id int) (*warehouseModels.Warehouse, error) {
+						return nil, apperrors.NewAppError("INTERNAL", "fail wh")
+					},
+				}
+			},
+			input:       testhelpers.CreateExpectedInboundOrder(0),
+			wantErrCode: "INTERNAL",
+		},
+		{
+			name: "warehouse not found",
+			// El warehouse no existe (devuelve error not found)
+			repoMock: func() *inboundOrderMocks.InboundOrderRepositoryMock {
+				return &inboundOrderMocks.InboundOrderRepositoryMock{
+					MockExistsByOrderNumber: func(ctx context.Context, orderNumber string) (bool, error) { return false, nil },
+				}
+			},
+			employeeMock: func() *employeeMocks.EmployeeRepositoryMock {
+				return &employeeMocks.EmployeeRepositoryMock{
+					MockFindByID: func(ctx context.Context, id int) (*employeeModels.Employee, error) {
+						e := testhelpers.CreateTestEmployee()
+						e.ID = id
+						return &e, nil
+					},
+				}
+			},
+			warehouseMock: func() *warehouseMocks.WarehouseRepositoryMock {
+				return &warehouseMocks.WarehouseRepositoryMock{
+					FuncFindById: func(ctx context.Context, id int) (*warehouseModels.Warehouse, error) {
+						return nil, apperrors.NewAppError("NOT_FOUND", "warehouse not found")
+					},
+				}
+			},
+			input:       testhelpers.CreateExpectedInboundOrder(0),
+			wantErrCode: "CONFLICT",
+		},
+		{
+			name: "warehouse nil",
+			// Referencia a warehouse no encontrada (devuelve nil)
+			repoMock: func() *inboundOrderMocks.InboundOrderRepositoryMock {
+				return &inboundOrderMocks.InboundOrderRepositoryMock{
+					MockExistsByOrderNumber: func(ctx context.Context, orderNumber string) (bool, error) { return false, nil },
+				}
+			},
+			employeeMock: func() *employeeMocks.EmployeeRepositoryMock {
+				return &employeeMocks.EmployeeRepositoryMock{
+					MockFindByID: func(ctx context.Context, id int) (*employeeModels.Employee, error) {
+						e := testhelpers.CreateTestEmployee()
+						e.ID = id
+						return &e, nil
+					},
+				}
+			},
+			warehouseMock: func() *warehouseMocks.WarehouseRepositoryMock {
+				return &warehouseMocks.WarehouseRepositoryMock{
+					FuncFindById: func(ctx context.Context, id int) (*warehouseModels.Warehouse, error) {
+						return nil, nil
+					},
+				}
+			},
+			input:       testhelpers.CreateExpectedInboundOrder(0),
+			wantErrCode: "CONFLICT",
+		},
+		{
+			name: "create repo error",
+			// Falla el insert en el repo (DB error)
+			repoMock: func() *inboundOrderMocks.InboundOrderRepositoryMock {
+				return &inboundOrderMocks.InboundOrderRepositoryMock{
+					MockExistsByOrderNumber: func(ctx context.Context, orderNumber string) (bool, error) { return false, nil },
+					MockCreate: func(ctx context.Context, o *models.InboundOrder) (*models.InboundOrder, error) {
+						return nil, apperrors.NewAppError("INTERNAL", "fail saving")
+					},
+				}
+			},
+			employeeMock: func() *employeeMocks.EmployeeRepositoryMock {
+				return &employeeMocks.EmployeeRepositoryMock{
+					MockFindByID: func(ctx context.Context, id int) (*employeeModels.Employee, error) {
+						e := testhelpers.CreateTestEmployee()
+						e.ID = id
+						return &e, nil
+					},
+				}
+			},
+			warehouseMock: func() *warehouseMocks.WarehouseRepositoryMock {
+				return &warehouseMocks.WarehouseRepositoryMock{
+					FuncFindById: func(ctx context.Context, id int) (*warehouseModels.Warehouse, error) {
+						return &warehouseModels.Warehouse{Id: id}, nil
+					},
+				}
+			},
+			input:       testhelpers.CreateExpectedInboundOrder(0),
+			wantErrCode: "INTERNAL",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := tc.repoMock()
+			empRepo := tc.employeeMock()
+			whRepo := tc.warehouseMock()
+			svc := service.NewInboundOrderService(repo, empRepo, whRepo)
+
+			res, err := svc.Create(context.Background(), tc.input)
+			if tc.wantErrCode == "" {
+				require.NoError(t, err)
+				require.NotNil(t, res)
+			} else {
+				require.Error(t, err)
+				appErr, ok := err.(*apperrors.AppError)
+				require.True(t, ok)
+				require.Equal(t, tc.wantErrCode, appErr.Code)
+				require.Nil(t, res)
+			}
+		})
+	}
+}

--- a/internal/service/inbound_order/inbound_order_read_test.go
+++ b/internal/service/inbound_order/inbound_order_read_test.go
@@ -1,0 +1,108 @@
+package service_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	service "github.com/varobledo_meli/W17-G10-Bootcamp.git/internal/service/inbound_order"
+	employeeMocks "github.com/varobledo_meli/W17-G10-Bootcamp.git/mocks/employee"
+	inboundOrderMocks "github.com/varobledo_meli/W17-G10-Bootcamp.git/mocks/inbound_order"
+	warehouseMocks "github.com/varobledo_meli/W17-G10-Bootcamp.git/mocks/warehouse"
+	models "github.com/varobledo_meli/W17-G10-Bootcamp.git/pkg/models/inbound_order"
+	"github.com/varobledo_meli/W17-G10-Bootcamp.git/testhelpers"
+)
+
+// Test unitario para el método Report del servicio de inbound orders,
+// cubriéndose los caminos de branch global (todos los empleados) y por empleado específico.
+func TestInboundOrderService_Report(t *testing.T) {
+	testCases := []struct {
+		name       string
+		repoMock   func() *inboundOrderMocks.InboundOrderRepositoryMock
+		employeeID *int // nil para ReportAll, con valor para ReportByID
+		wantEmpty  bool // espera reporte vacío
+		wantErr    bool
+	}{
+		{
+			name: "report_all_ok",
+			// Cuando employeeID es nil, se espera un reporte "global".
+			repoMock: func() *inboundOrderMocks.InboundOrderRepositoryMock {
+				return &inboundOrderMocks.InboundOrderRepositoryMock{
+					// Usa el helper para un listado dummy
+					MockReportAll: func(ctx context.Context) ([]models.InboundOrderReport, error) {
+						return testhelpers.CreateInboundOrderReports(), nil
+					},
+				}
+			},
+			employeeID: nil,   // Simula llamada general
+			wantEmpty:  false, // Debe haber datos
+			wantErr:    false,
+		},
+		{
+			name: "report_by_id_ok",
+			// Cuando employeeID está presente, se espera un solo reporte.
+			repoMock: func() *inboundOrderMocks.InboundOrderRepositoryMock {
+				return &inboundOrderMocks.InboundOrderRepositoryMock{
+					MockReportByID: func(ctx context.Context, id int) (*models.InboundOrderReport, error) {
+						r := testhelpers.CreateInboundOrderReport(id)
+						return &r, nil // Simula encontrado
+					},
+				}
+			},
+			employeeID: func() *int { v := 1; return &v }(), // busca un id específico
+			wantEmpty:  false,
+			wantErr:    false,
+		},
+		{
+			name: "report_by_id_not_found",
+			// Simula el camino donde no hay empleado
+			repoMock: func() *inboundOrderMocks.InboundOrderRepositoryMock {
+				return &inboundOrderMocks.InboundOrderRepositoryMock{
+					MockReportByID: func(ctx context.Context, id int) (*models.InboundOrderReport, error) {
+						return nil, nil // Simula "no encontrado"
+					},
+				}
+			},
+			employeeID: func() *int { v := 999; return &v }(),
+			wantEmpty:  true,  // Espera que no haya datos (nil)
+			wantErr:    false, // Aquí no es error, solo no hay datos
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Crea los mocks de Repos necesarios (los otros no relevantes pueden estar vacíos/dummy)
+			repo := tc.repoMock()
+			empRepo := &employeeMocks.EmployeeRepositoryMock{}
+			whRepo := &warehouseMocks.WarehouseRepositoryMock{}
+			svc := service.NewInboundOrderService(repo, empRepo, whRepo)
+
+			// Ejecuta el método Report
+			result, err := svc.Report(context.Background(), tc.employeeID)
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				if tc.employeeID == nil {
+					// Caso branch global: debe ser un slice (list)
+					reports, ok := result.([]models.InboundOrderReport)
+					require.True(t, ok)
+					if tc.wantEmpty {
+						require.Empty(t, reports)
+					} else {
+						require.NotEmpty(t, reports)
+					}
+				} else {
+					// Caso por empleado: debe ser pointer o nil
+					rep, ok := result.(*models.InboundOrderReport)
+					require.True(t, ok)
+					if tc.wantEmpty {
+						require.Nil(t, rep)
+					} else {
+						require.NotNil(t, rep)
+					}
+				}
+			}
+		})
+	}
+}

--- a/mocks/inbound_order/inbound_order_repository_mock.go
+++ b/mocks/inbound_order/inbound_order_repository_mock.go
@@ -1,0 +1,27 @@
+package mocks
+
+import (
+	"context"
+
+	models "github.com/varobledo_meli/W17-G10-Bootcamp.git/pkg/models/inbound_order"
+)
+
+type InboundOrderRepositoryMock struct {
+	MockCreate              func(ctx context.Context, o *models.InboundOrder) (*models.InboundOrder, error)
+	MockExistsByOrderNumber func(ctx context.Context, orderNumber string) (bool, error)
+	MockReportAll           func(ctx context.Context) ([]models.InboundOrderReport, error)
+	MockReportByID          func(ctx context.Context, employeeID int) (*models.InboundOrderReport, error)
+}
+
+func (m *InboundOrderRepositoryMock) Create(ctx context.Context, o *models.InboundOrder) (*models.InboundOrder, error) {
+	return m.MockCreate(ctx, o)
+}
+func (m *InboundOrderRepositoryMock) ExistsByOrderNumber(ctx context.Context, orderNumber string) (bool, error) {
+	return m.MockExistsByOrderNumber(ctx, orderNumber)
+}
+func (m *InboundOrderRepositoryMock) ReportAll(ctx context.Context) ([]models.InboundOrderReport, error) {
+	return m.MockReportAll(ctx)
+}
+func (m *InboundOrderRepositoryMock) ReportByID(ctx context.Context, employeeID int) (*models.InboundOrderReport, error) {
+	return m.MockReportByID(ctx, employeeID)
+}


### PR DESCRIPTION
**Descripción**

- Se agregó un mock para el repositorio de inbound_orders, permitiendo simular todos los caminos posibles en la lógica sin depender de una base de datos real.
- Se implementaron tests unitarios para el service de inbound_orders (tanto para creación como para reportes), utilizando helpers centralizados (testhelpers) para generar datos de prueba de manera DRY y consistente.