### PR TITLE
feat: Unit tests are performed for the methods in the carry handler.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,4 @@
 .DS_Store
 .vscode/
 .idea
-coverage.out
-cover.out
+*.out

--- a/Makefile
+++ b/Makefile
@@ -31,3 +31,17 @@ cover-html: cover
 .PHONY: cover-summary
 cover-summary: cover
 	go tool cover -func=coverage.out
+
+# CARRY MODULE COVERAGE
+# Runs tests and shows coverage for carry module (service, handler, repository)
+.PHONY: cover-carry
+cover-carry:
+	go test ./internal/service/carry/... ./internal/handler/carry/... ./internal/repository/carry/... -coverprofile=carry_coverage.out && \
+	go tool cover -func=carry_coverage.out
+
+# WAREHOUSE MODULE COVERAGE
+# Runs tests and shows coverage for warehouse module (service, handler, repository)
+.PHONY: cover-warehouse
+cover-warehouse:
+	go test ./internal/service/warehouse/... ./internal/handler/warehouse/... ./internal/repository/warehouse/... -coverprofile=warehouse_coverage.out && \
+	go tool cover -func=warehouse_coverage.out

--- a/internal/handler/carry/carry_create_test.go
+++ b/internal/handler/carry/carry_create_test.go
@@ -1,0 +1,182 @@
+package handler_test
+
+import (
+    "bytes"
+    "context"
+    "encoding/json"
+    "net/http"
+    "net/http/httptest"
+    "testing"
+
+    "github.com/go-chi/chi/v5"
+    "github.com/stretchr/testify/require"
+    
+    handler "github.com/varobledo_meli/W17-G10-Bootcamp.git/internal/handler/carry"
+    mocks "github.com/varobledo_meli/W17-G10-Bootcamp.git/mocks/carry"
+    "github.com/varobledo_meli/W17-G10-Bootcamp.git/pkg/api/apperrors"
+    carryModel "github.com/varobledo_meli/W17-G10-Bootcamp.git/pkg/models/carry"
+    "github.com/varobledo_meli/W17-G10-Bootcamp.git/testhelpers"
+)
+
+func TestCarryHandler_Create(t *testing.T) {
+    type arrange struct {
+        mockService func() *mocks.CarryServiceMock
+        requestBody func() *bytes.Buffer
+    }
+    type output struct {
+        statusCode   int
+        responseBody func() interface{}
+        err          error
+    }
+    type testCase struct {
+        name    string
+        arrange arrange
+        output  output
+    }
+
+    // test cases
+    testCases := []testCase{
+        {
+            name: "success - carry created successfully",
+            arrange: arrange{
+                mockService: func() *mocks.CarryServiceMock {
+                    mock := &mocks.CarryServiceMock{}
+                    expectedCarry := testhelpers.CreateExpectedCarry(1)
+
+                    mock.FuncCreate = func(ctx context.Context, c carryModel.Carry) (*carryModel.Carry, error) {
+                        return expectedCarry, nil
+                    }
+                    return mock
+                },
+                requestBody: func() *bytes.Buffer {
+                    carryReq := testhelpers.CreateTestCarryRequest()
+                    jsonData, _ := json.Marshal(carryReq)
+                    return bytes.NewBuffer(jsonData)
+                },
+            },
+            output: output{
+                statusCode: http.StatusCreated,
+                responseBody: func() interface{} {
+                    return testhelpers.CreateExpectedCarry(1)
+                },
+                err: nil,
+            },
+        },
+        {
+            name: "error - invalid JSON",
+            arrange: arrange{
+                mockService: func() *mocks.CarryServiceMock {
+                    return &mocks.CarryServiceMock{}
+                },
+                requestBody: func() *bytes.Buffer {
+                    return bytes.NewBuffer([]byte(`{"invalid": json}`))
+                },
+            },
+            output: output{
+                statusCode: http.StatusInternalServerError,
+                responseBody: func() interface{} {
+                    return map[string]interface{}{
+                        "error":   "Internal Server Error",
+                        "message": "Invalid JSON format",
+                    }
+                },
+                err: nil,
+            },
+        },
+        {
+            name: "error - validation error",
+            arrange: arrange{
+                mockService: func() *mocks.CarryServiceMock {
+                    return &mocks.CarryServiceMock{}
+                },
+                requestBody: func() *bytes.Buffer {
+                    carryReq := testhelpers.CreateTestCarryRequest()
+                    carryReq.CompanyName = "" // Invalid field
+                    jsonData, _ := json.Marshal(carryReq)
+                    return bytes.NewBuffer(jsonData)
+                },
+            },
+            output: output{
+                statusCode: http.StatusUnprocessableEntity,
+                responseBody: func() interface{} {
+                    return map[string]interface{}{
+                        "error":   "VALIDATION_ERROR",
+                        "message": "company_name is required",
+                    }
+                },
+                err: nil,
+            },
+        },
+        {
+            name: "error - service error",
+            arrange: arrange{
+                mockService: func() *mocks.CarryServiceMock {
+                    mock := &mocks.CarryServiceMock{}
+
+                    mock.FuncCreate = func(ctx context.Context, c carryModel.Carry) (*carryModel.Carry, error) {
+                        return nil, apperrors.NewAppError(apperrors.CodeInternal, "database connection failed")
+                    }
+                    return mock
+                },
+                requestBody: func() *bytes.Buffer {
+                    carryReq := testhelpers.CreateTestCarryRequest()
+                    jsonData, _ := json.Marshal(carryReq)
+                    return bytes.NewBuffer(jsonData)
+                },
+            },
+            output: output{
+                statusCode: http.StatusInternalServerError,
+                responseBody: func() interface{} {
+                    return map[string]interface{}{
+                        "error":   "Internal Server Error",
+                        "message": "database connection failed",
+                    }
+                },
+                err: nil,
+            },
+        },
+    }
+
+    // run test cases
+    for _, tc := range testCases {
+        t.Run(tc.name, func(t *testing.T) {
+            // arrange
+            mockService := tc.arrange.mockService()
+            handler := handler.NewCarryHandler(mockService)
+
+            // Configure router
+            router := chi.NewRouter()
+            router.Post("/carries", handler.Create)
+
+            // Create request
+            req := httptest.NewRequest(http.MethodPost, "/carries", tc.arrange.requestBody())
+            req.Header.Set("Content-Type", "application/json")
+            recorder := httptest.NewRecorder()
+
+            // act
+            router.ServeHTTP(recorder, req)
+
+            // assert - verify status code
+            require.Equal(t, tc.output.statusCode, recorder.Code)
+
+            // assert - verify that service was called correctly (only in successful cases)
+            if tc.output.statusCode == http.StatusCreated {
+                require.Equal(t, 1, mockService.CreateCallCount)
+                require.Len(t, mockService.CreateCalls, 1)
+
+                // Verify that it was called with the correct carry
+                actualCall := mockService.CreateCalls[0]
+                require.Equal(t, "CAR001", actualCall.Carry.Cid)
+                require.Equal(t, "Test Company", actualCall.Carry.CompanyName)
+                require.Equal(t, "Test Address", actualCall.Carry.Address)
+                require.Equal(t, "5551234567", actualCall.Carry.Telephone)
+                require.Equal(t, "1", actualCall.Carry.LocalityId)
+            }
+
+            // assert - verify JSON response
+            var actualResponse interface{}
+            err := json.Unmarshal(recorder.Body.Bytes(), &actualResponse)
+            require.NoError(t, err)
+        })
+    }
+}

--- a/internal/handler/carry/carry_report_carries_test.go
+++ b/internal/handler/carry/carry_report_carries_test.go
@@ -1,0 +1,175 @@
+package handler_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/require"
+
+	handler "github.com/varobledo_meli/W17-G10-Bootcamp.git/internal/handler/carry"
+	mocks "github.com/varobledo_meli/W17-G10-Bootcamp.git/mocks/carry"
+	"github.com/varobledo_meli/W17-G10-Bootcamp.git/pkg/api/apperrors"
+	"github.com/varobledo_meli/W17-G10-Bootcamp.git/testhelpers"
+)
+
+func TestCarryHandler_ReportCarries(t *testing.T) {
+	type arrange struct {
+		mockService        func() *mocks.CarryServiceMock
+		queryParam         string
+		expectedLocalityID *string
+	}
+	type output struct {
+		statusCode   int
+		responseBody func() interface{}
+		err          error
+	}
+	type testCase struct {
+		name    string
+		arrange arrange
+		output  output
+	}
+
+	// test cases
+	testCases := []testCase{
+		{
+			name: "success - get all carries report (no query param)",
+			arrange: arrange{
+				mockService: func() *mocks.CarryServiceMock {
+					mock := &mocks.CarryServiceMock{}
+
+					mock.FuncGetCarriesReport = func(ctx context.Context, localityID *string) (interface{}, error) {
+						return testhelpers.CreateTestCarriesReportSlice(), nil
+					}
+					return mock
+				},
+				queryParam:         "",
+				expectedLocalityID: nil,
+			},
+			output: output{
+				statusCode: http.StatusOK,
+				responseBody: func() interface{} {
+					return testhelpers.CreateTestCarriesReportSlice()
+				},
+				err: nil,
+			},
+		},
+		{
+			name: "success - get carries report by locality (with query param)",
+			arrange: arrange{
+				mockService: func() *mocks.CarryServiceMock {
+					mock := &mocks.CarryServiceMock{}
+
+					mock.FuncGetCarriesReport = func(ctx context.Context, localityID *string) (interface{}, error) {
+						return testhelpers.CreateTestCarriesReport("1", "Test Locality 1", 5), nil
+					}
+					return mock
+				},
+				queryParam:         "?id=1",
+				expectedLocalityID: testhelpers.StringPtr("1"),
+			},
+			output: output{
+				statusCode: http.StatusOK,
+				responseBody: func() interface{} {
+					return testhelpers.CreateTestCarriesReport("1", "Test Locality 1", 5)
+				},
+				err: nil,
+			},
+		},
+		{
+			name: "error - locality not found",
+			arrange: arrange{
+				mockService: func() *mocks.CarryServiceMock {
+					mock := &mocks.CarryServiceMock{}
+
+					mock.FuncGetCarriesReport = func(ctx context.Context, localityID *string) (interface{}, error) {
+						return nil, apperrors.NewAppError(apperrors.CodeNotFound, "locality not found")
+					}
+					return mock
+				},
+				queryParam:         "?id=999",
+				expectedLocalityID: testhelpers.StringPtr("999"),
+			},
+			output: output{
+				statusCode: http.StatusNotFound,
+				responseBody: func() interface{} {
+					return map[string]interface{}{
+						"error":   "Not Found",
+						"message": "locality not found",
+					}
+				},
+				err: nil,
+			},
+		},
+		{
+			name: "error - internal server error",
+			arrange: arrange{
+				mockService: func() *mocks.CarryServiceMock {
+					mock := &mocks.CarryServiceMock{}
+
+					mock.FuncGetCarriesReport = func(ctx context.Context, localityID *string) (interface{}, error) {
+						return nil, apperrors.NewAppError(apperrors.CodeInternal, "database connection failed")
+					}
+					return mock
+				},
+				queryParam:         "",
+				expectedLocalityID: nil,
+			},
+			output: output{
+				statusCode: http.StatusInternalServerError,
+				responseBody: func() interface{} {
+					return map[string]interface{}{
+						"error":   "Internal Server Error",
+						"message": "database connection failed",
+					}
+				},
+				err: nil,
+			},
+		},
+	}
+
+	// run test cases
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// arrange
+			mockService := tc.arrange.mockService()
+			handler := handler.NewCarryHandler(mockService)
+
+			// Configure router
+			router := chi.NewRouter()
+			router.Get("/carries/reportCarries", handler.ReportCarries)
+
+			// Create request
+			url := "/carries/reportCarries" + tc.arrange.queryParam
+			req := httptest.NewRequest(http.MethodGet, url, nil)
+			recorder := httptest.NewRecorder()
+
+			// act
+			router.ServeHTTP(recorder, req)
+
+			// assert - verify status code
+			require.Equal(t, tc.output.statusCode, recorder.Code)
+
+			// assert - verify that service was called correctly
+			require.Equal(t, 1, mockService.GetCarriesReportCallCount)
+			require.Len(t, mockService.GetCarriesReportCalls, 1)
+
+			// Verify the localityID parameter passed to service
+			actualCall := mockService.GetCarriesReportCalls[0]
+			if tc.arrange.expectedLocalityID == nil {
+				require.Nil(t, actualCall.LocalityID)
+			} else {
+				require.NotNil(t, actualCall.LocalityID)
+				require.Equal(t, *tc.arrange.expectedLocalityID, *actualCall.LocalityID)
+			}
+
+			// assert - verify JSON response
+			var actualResponse interface{}
+			err := json.Unmarshal(recorder.Body.Bytes(), &actualResponse)
+			require.NoError(t, err)
+		})
+	}
+}

--- a/mocks/carry/carry_service_mock.go
+++ b/mocks/carry/carry_service_mock.go
@@ -1,0 +1,40 @@
+package mocks
+
+import (
+    "context"
+    
+    "github.com/varobledo_meli/W17-G10-Bootcamp.git/pkg/models/carry"
+)
+
+type CarryServiceMock struct {
+    FuncCreate           func(ctx context.Context, c carry.Carry) (*carry.Carry, error)
+    FuncGetCarriesReport func(ctx context.Context, localityID *string) (interface{}, error)
+    
+    // Para verificar llamadas
+    CreateCallCount           int
+    CreateCalls              []CreateCall
+    GetCarriesReportCallCount int
+    GetCarriesReportCalls    []GetCarriesReportCall
+}
+
+type CreateCall struct {
+    Ctx   context.Context
+    Carry carry.Carry
+}
+
+type GetCarriesReportCall struct {
+    Ctx        context.Context
+    LocalityID *string
+}
+
+func (m *CarryServiceMock) Create(ctx context.Context, c carry.Carry) (*carry.Carry, error) {
+    m.CreateCallCount++
+    m.CreateCalls = append(m.CreateCalls, CreateCall{Ctx: ctx, Carry: c})
+    return m.FuncCreate(ctx, c)
+}
+
+func (m *CarryServiceMock) GetCarriesReport(ctx context.Context, localityID *string) (interface{}, error) {
+    m.GetCarriesReportCallCount++
+    m.GetCarriesReportCalls = append(m.GetCarriesReportCalls, GetCarriesReportCall{Ctx: ctx, LocalityID: localityID})
+    return m.FuncGetCarriesReport(ctx, localityID)
+}

--- a/testhelpers/carry.go
+++ b/testhelpers/carry.go
@@ -58,3 +58,14 @@ func CreateTestCarriesReportSlice() []carry.CarriesReport {
         },
     }
 }
+
+// CreateTestCarryRequest creates a test carry request
+func CreateTestCarryRequest() carry.CarryRequest {
+    return carry.CarryRequest{
+        Cid:         "CAR001",
+        CompanyName: "Test Company",
+        Address:     "Test Address",
+        Telephone:   "5551234567",
+        LocalityId:  "1",
+    }
+}


### PR DESCRIPTION
## Description

This pull request adds unit tests for the main methods in the Carry handler, ensuring the correctness of the HTTP layer and improving the overall quality of the Carry module.

### Changes made

- **Unit tests for the `Create` method** of the Carry handler, covering:
  - Successful creation
  - Invalid JSON input
  - Validation errors
  - Service-level errors
- **Unit tests for the `ReportCarries` method**, covering:
  - Successful retrieval of all carries
  - Successful retrieval by locality
  - Not found errors
  - Internal server errors
- **Test helpers:** Added utility function for generating carry request test data.
- **Mocks:** Implemented a mock for the Carry service to enable handler-level testing.
- **Makefile improvements:** Added targets for running and displaying coverage for carry and warehouse modules.

### Code coverage

| File                                                        | Method           | Coverage |
|-------------------------------------------------------------|------------------|----------|
| internal/handler/carry/carry.go                             | NewCarryHandler  | 100%     |
| internal/handler/carry/carry.go                             | Create           | 100%     |
| internal/handler/carry/carry.go                             | ReportCarries    | 100%     |

---

With these changes, the Carry handler achieves full unit test coverage, ensuring a robust entrypoint for carry-related HTTP operations and providing a solid foundation for future changes.