### PR TITLE
feature: added unit tests for repository of inbound_orders and added comments in code for unit tests of employees repository

### DIFF
--- a/internal/repository/employee/employee_create_test.go
+++ b/internal/repository/employee/employee_create_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/varobledo_meli/W17-G10-Bootcamp.git/testhelpers"
 )
 
+// Test unitario del método Create del repositorio de empleados usando helpers y sqlmock.
 func TestEmployeeRepository_Create(t *testing.T) {
 	testCases := []struct {
 		name      string
@@ -21,10 +22,12 @@ func TestEmployeeRepository_Create(t *testing.T) {
 	}{
 		{
 			name: "inserta_ok",
+			// Usa el helper para generar un employee dummy válido
 			input: func() *models.Employee {
 				e := testhelpers.CreateTestEmployee() // struct
 				return &e
 			}(),
+			// Simula un insert exitoso en la base, retorna una fila insertada con id=1
 			mockSetup: func(mock sqlmock.Sqlmock, in models.Employee) {
 				mock.ExpectExec("INSERT INTO employees").
 					WithArgs(in.CardNumberID, in.FirstName, in.LastName, in.WarehouseID).
@@ -34,6 +37,7 @@ func TestEmployeeRepository_Create(t *testing.T) {
 		},
 		{
 			name: "error_db_exec",
+			// Cambia un campo para simular una situación errónea o borde
 			input: func() *models.Employee {
 				e := testhelpers.CreateTestEmployee()
 				e.CardNumberID = "ERR"
@@ -42,6 +46,7 @@ func TestEmployeeRepository_Create(t *testing.T) {
 				e.WarehouseID = 5
 				return &e
 			}(),
+			// Simula que la BD falla al ejecutar el insert
 			mockSetup: func(mock sqlmock.Sqlmock, in models.Employee) {
 				mock.ExpectExec("INSERT INTO employees").
 					WithArgs(in.CardNumberID, in.FirstName, in.LastName, in.WarehouseID).
@@ -51,6 +56,7 @@ func TestEmployeeRepository_Create(t *testing.T) {
 		},
 		{
 			name: "error_last_insert_id",
+			// Cambia los campos para otro caso y simula error al obtener el id
 			input: func() *models.Employee {
 				e := testhelpers.CreateTestEmployee()
 				e.CardNumberID = "ID2"
@@ -59,6 +65,7 @@ func TestEmployeeRepository_Create(t *testing.T) {
 				e.WarehouseID = 9
 				return &e
 			}(),
+			// El insert ocurre pero falla al obtener el LastInsertId
 			mockSetup: func(mock sqlmock.Sqlmock, in models.Employee) {
 				mock.ExpectExec("INSERT INTO employees").
 					WithArgs(in.CardNumberID, in.FirstName, in.LastName, in.WarehouseID).
@@ -70,9 +77,10 @@ func TestEmployeeRepository_Create(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			// Crea un mock de la DB y el sqlmock que interceptará consultas
 			mock, db := testhelpers.CreateMockDB()
 			defer db.Close()
-
+			// Convierte el input de puntero a struct para pasárselo al mock setup
 			in := *tc.input // struct para mock
 			tc.mockSetup(mock, in)
 
@@ -86,8 +94,9 @@ func TestEmployeeRepository_Create(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 				require.NotZero(t, emp.ID)
-				require.Equal(t, in.FirstName, emp.FirstName)
+				require.Equal(t, in.FirstName, emp.FirstName) // verifica el nombre creado
 			}
+			// Valida que todas las queries esperadas se hayan ejecutado (sqlmock)
 			require.NoError(t, mock.ExpectationsWereMet())
 		})
 	}

--- a/internal/repository/employee/employee_delete_test.go
+++ b/internal/repository/employee/employee_delete_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/varobledo_meli/W17-G10-Bootcamp.git/testhelpers"
 )
 
+// Test unitario del método Delete del repositorio de employees usando sqlmock.
 func TestEmployeeRepository_Delete(t *testing.T) {
 	testCases := []struct {
 		name      string
@@ -21,16 +22,18 @@ func TestEmployeeRepository_Delete(t *testing.T) {
 		{
 			name:    "delete_ok",
 			inputID: 10,
+			// Simula que la query DELETE ejecuta correctamente y borra 1 fila
 			mockSetup: func(mock sqlmock.Sqlmock) {
 				mock.ExpectExec("DELETE FROM employees").
 					WithArgs(10).
-					WillReturnResult(sqlmock.NewResult(0, 1))
+					WillReturnResult(sqlmock.NewResult(0, 1)) // 1 fila borrada
 			},
 			expectErr: false,
 		},
 		{
 			name:    "delete_db_error",
 			inputID: 11,
+			// Simula que la BD falla al ejecutar el delete
 			mockSetup: func(mock sqlmock.Sqlmock) {
 				mock.ExpectExec("DELETE FROM employees").
 					WithArgs(11).
@@ -41,16 +44,18 @@ func TestEmployeeRepository_Delete(t *testing.T) {
 		{
 			name:    "no_rows_affected",
 			inputID: 12,
+			// Simula que el DELETE ejecuta pero no borra ninguna fila (empleado no existe)
 			mockSetup: func(mock sqlmock.Sqlmock) {
 				mock.ExpectExec("DELETE FROM employees").
 					WithArgs(12).
-					WillReturnResult(sqlmock.NewResult(0, 0))
+					WillReturnResult(sqlmock.NewResult(0, 0)) // 0 filas borradas
 			},
 			expectErr: true,
 		},
 		{
 			name:    "rows_affected_fails",
 			inputID: 13,
+			// Simula que hay un error al preguntar cuántas filas fueron afectadas (poco común)
 			mockSetup: func(mock sqlmock.Sqlmock) {
 				mock.ExpectExec("DELETE FROM employees").
 					WithArgs(13).
@@ -62,18 +67,21 @@ func TestEmployeeRepository_Delete(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			// Usa el helper para armar DB/mock (DRY)
 			mock, db := testhelpers.CreateMockDB()
 			defer db.Close()
-
+			// Configura el escenario de query esperado para el caso
 			tc.mockSetup(mock)
 			repo := repo.NewEmployeeRepository(db)
 			ctx := context.Background()
+			// Ejecuta el método Delete
 			err := repo.Delete(ctx, tc.inputID)
 			if tc.expectErr {
 				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
 			}
+			// Valida que no quedó ningún EXPECT sin ejecutar en el mock (verifica cobertura total de queries)
 			require.NoError(t, mock.ExpectationsWereMet())
 		})
 	}

--- a/internal/repository/employee/employee_read_test.go
+++ b/internal/repository/employee/employee_read_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/varobledo_meli/W17-G10-Bootcamp.git/testhelpers"
 )
 
+// Test FindByID y FindByCardNumberID, usando helpers dummy y sqlmock para queries
 func TestEmployeeRepository_Read(t *testing.T) {
 	testCases := []struct {
 		name      string
@@ -25,7 +26,8 @@ func TestEmployeeRepository_Read(t *testing.T) {
 		{
 			name:   "byID_ok",
 			method: "FindByID",
-			id:     1,
+			// Simula que la query retorna el empleado esperado
+			id: 1,
 			setup: func(mock sqlmock.Sqlmock, expected *models.Employee) {
 				rows := sqlmock.NewRows([]string{"id", "id_card_number", "first_name", "last_name", "wareHouse_id"}).
 					AddRow(expected.ID, expected.CardNumberID, expected.FirstName, expected.LastName, expected.WarehouseID)
@@ -40,6 +42,7 @@ func TestEmployeeRepository_Read(t *testing.T) {
 			name:   "byID_not_found",
 			method: "FindByID",
 			id:     20,
+			// Simula que no hay ningún empleado con ese id
 			setup: func(mock sqlmock.Sqlmock, _ *models.Employee) {
 				mock.ExpectQuery("SELECT id, id_card_number, first_name, last_name, wareHouse_id FROM employees WHERE id=?").
 					WithArgs(20).
@@ -52,6 +55,7 @@ func TestEmployeeRepository_Read(t *testing.T) {
 			name:   "byID_query_err",
 			method: "FindByID",
 			id:     21,
+			// Simula un error de ejecución de la query
 			setup: func(mock sqlmock.Sqlmock, _ *models.Employee) {
 				mock.ExpectQuery("SELECT id, id_card_number, first_name, last_name, wareHouse_id FROM employees WHERE id=?").
 					WithArgs(21).
@@ -65,6 +69,7 @@ func TestEmployeeRepository_Read(t *testing.T) {
 			name:   "byCard_ok",
 			method: "FindByCardNumberID",
 			cardID: "EMP001",
+			// Simula una búsqueda por número de tarjeta exitosa
 			setup: func(mock sqlmock.Sqlmock, expected *models.Employee) {
 				rows := sqlmock.NewRows([]string{"id", "id_card_number", "first_name", "last_name", "wareHouse_id"}).
 					AddRow(expected.ID, expected.CardNumberID, expected.FirstName, expected.LastName, expected.WarehouseID)
@@ -79,6 +84,7 @@ func TestEmployeeRepository_Read(t *testing.T) {
 			name:   "byCard_not_found",
 			method: "FindByCardNumberID",
 			cardID: "QX",
+			// No existe empleado con el card_number dado
 			setup: func(mock sqlmock.Sqlmock, _ *models.Employee) {
 				mock.ExpectQuery("SELECT id, id_card_number, first_name, last_name, wareHouse_id FROM employees WHERE id_card_number=?").
 					WithArgs("QX").
@@ -91,6 +97,7 @@ func TestEmployeeRepository_Read(t *testing.T) {
 			name:   "byCard_query_err",
 			method: "FindByCardNumberID",
 			cardID: "ERRCARD",
+			// Simula error en la query por card_number_id
 			setup: func(mock sqlmock.Sqlmock, _ *models.Employee) {
 				mock.ExpectQuery("SELECT id, id_card_number, first_name, last_name, wareHouse_id FROM employees WHERE id_card_number=?").
 					WithArgs("ERRCARD").
@@ -103,6 +110,7 @@ func TestEmployeeRepository_Read(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			// Crea la DB y el mock con helpers
 			mock, db := testhelpers.CreateMockDB()
 			defer db.Close()
 
@@ -152,6 +160,8 @@ func TestEmployeeRepository_Read(t *testing.T) {
 		})
 	}
 }
+
+// Test para FindAll, usando helpers para el listado y cubriendo todos los posibles errores/resultados
 func TestEmployeeRepository_FindAll(t *testing.T) {
 	testCases := []struct {
 		name      string

--- a/internal/repository/employee/employee_update_test.go
+++ b/internal/repository/employee/employee_update_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/varobledo_meli/W17-G10-Bootcamp.git/testhelpers"
 )
 
+// Test unitario del método Update del repositorio de empleados usando sqlmock y helpers DRY.
 func TestEmployeeRepository_Update(t *testing.T) {
 	testCases := []struct {
 		name      string
@@ -23,6 +24,7 @@ func TestEmployeeRepository_Update(t *testing.T) {
 		{
 			name: "update_ok",
 			id:   22,
+			// Usa el helper para crear un employee dummy y luego personaliza campos para el caso
 			input: func() *models.Employee {
 				e := testhelpers.CreateTestEmployee()
 				e.CardNumberID = "A1"
@@ -31,6 +33,7 @@ func TestEmployeeRepository_Update(t *testing.T) {
 				e.WarehouseID = 99
 				return &e
 			}(),
+			// Simula que la actualización en la DB es exitosa para esos campos
 			mockSetup: func(mock sqlmock.Sqlmock, in models.Employee) {
 				mock.ExpectExec("UPDATE employees").
 					WithArgs("A1", "Daniela", "Zamora", 99, 22).
@@ -41,6 +44,7 @@ func TestEmployeeRepository_Update(t *testing.T) {
 		{
 			name: "update_db_error",
 			id:   24,
+			// Modifica los campos básicos para simular otro caso de update
 			input: func() *models.Employee {
 				e := testhelpers.CreateTestEmployee()
 				e.CardNumberID = "B1"
@@ -49,6 +53,7 @@ func TestEmployeeRepository_Update(t *testing.T) {
 				e.WarehouseID = 88
 				return &e
 			}(),
+			// Simula que la DB devuelve un error al ejecutar el update
 			mockSetup: func(mock sqlmock.Sqlmock, in models.Employee) {
 				mock.ExpectExec("UPDATE employees").
 					WithArgs("B1", "Falla", "Falla", 88, 24).
@@ -60,20 +65,23 @@ func TestEmployeeRepository_Update(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			// Helper para crear conexión y mock sqlmock
 			mock, db := testhelpers.CreateMockDB()
 			defer db.Close()
-
+			// Valor a usar en el setup del mock
 			in := *tc.input
 			tc.mockSetup(mock, in)
 
 			repo := repo.NewEmployeeRepository(db)
 			ctx := context.Background()
+			// Ejecuta el método Update del repo
 			err := repo.Update(ctx, tc.id, tc.input)
 			if tc.expectErr {
 				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
 			}
+			// Chequea que todas las queries esperadas hayan sido ejecutadas
 			require.NoError(t, mock.ExpectationsWereMet())
 		})
 	}

--- a/internal/repository/inbound_order/inbound_order_exists_test.go
+++ b/internal/repository/inbound_order/inbound_order_exists_test.go
@@ -1,0 +1,80 @@
+package repository_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/require"
+	repo "github.com/varobledo_meli/W17-G10-Bootcamp.git/internal/repository/inbound_order"
+)
+
+// Test para ExistsByOrderNumber: verifica consulta de unicidad de número de orden
+func TestInboundOrderRepository_ExistsByOrderNumber(t *testing.T) {
+	testCases := []struct {
+		name      string
+		orderNum  string
+		mockSetup func(sqlmock.Sqlmock)
+		expected  bool
+		expectErr bool
+	}{
+		{
+			name:     "exists_true",
+			orderNum: "INV001",
+			// Simula que la query retorna un count=1 (número ya existe)
+			mockSetup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery("SELECT COUNT\\(1\\) FROM inbound_orders WHERE order_number = ?").
+					WithArgs("INV001").
+					WillReturnRows(sqlmock.NewRows([]string{"COUNT(1)"}).AddRow(1))
+			},
+			expected:  true,
+			expectErr: false,
+		},
+		{
+			name:     "exists_false",
+			orderNum: "INV002",
+			// Simula que la query retorna un count=0 (número no existe)
+			mockSetup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery("SELECT COUNT\\(1\\) FROM inbound_orders WHERE order_number = ?").
+					WithArgs("INV002").
+					WillReturnRows(sqlmock.NewRows([]string{"COUNT(1)"}).AddRow(0))
+			},
+			expected:  false,
+			expectErr: false,
+		},
+		{
+			name:     "scan_error",
+			orderNum: "INV003",
+			// Simula un error de ejecución/scan en la query
+			mockSetup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery("SELECT COUNT\\(1\\) FROM inbound_orders WHERE order_number = ?").
+					WithArgs("INV003").
+					WillReturnError(errors.New("db error"))
+			},
+			expected:  false,
+			expectErr: true,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// sqlmock crea la "db" en memoria y un mock para interceptar queries
+			db, mock, err := sqlmock.New()
+			require.NoError(t, err)
+			defer db.Close()
+
+			tc.mockSetup(mock) // Setup para este test en concreto
+
+			repository := repo.NewInboundOrderRepository(db)
+			res, err := repository.ExistsByOrderNumber(context.Background(), tc.orderNum)
+
+			if tc.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.expected, res) // True/False según test
+			}
+			require.NoError(t, mock.ExpectationsWereMet()) // Checa que no hay queries faltantes
+		})
+	}
+}

--- a/internal/repository/inbound_order/inbound_order_read_test.go
+++ b/internal/repository/inbound_order/inbound_order_read_test.go
@@ -1,0 +1,151 @@
+package repository_test
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/require"
+	repo "github.com/varobledo_meli/W17-G10-Bootcamp.git/internal/repository/inbound_order"
+)
+
+// Test unitario de ReportAll: repote agrupado de todos los empleados
+func TestInboundOrderRepository_ReportAll(t *testing.T) {
+	testCases := []struct {
+		name      string
+		mockSetup func(sqlmock.Sqlmock)
+		wantEmpty bool
+		expectErr bool
+	}{
+		{
+			name: "report_ok",
+			// Devuelve dos filas, simulando dos empleados con inbound_orders
+			mockSetup: func(mock sqlmock.Sqlmock) {
+				rows := sqlmock.NewRows(
+					[]string{"id", "id_card_number", "first_name", "last_name", "warehouse_id", "inbound_orders_count"},
+				).
+					AddRow(1, "CARDID", "Juan", "Tester", 1, 3).
+					AddRow(2, "CARDID2", "Alma", "Otro", 2, 1)
+				mock.ExpectQuery("SELECT e.id, e.id_card_number,").WillReturnRows(rows)
+			},
+			wantEmpty: false,
+			expectErr: false,
+		},
+		{
+			name: "report_empty",
+			// Devuelve resultset vacío (sin empleados)
+			mockSetup: func(mock sqlmock.Sqlmock) {
+				rows := sqlmock.NewRows(
+					[]string{"id", "id_card_number", "first_name", "last_name", "warehouse_id", "inbound_orders_count"},
+				)
+				mock.ExpectQuery("SELECT e.id, e.id_card_number,").WillReturnRows(rows)
+			},
+			wantEmpty: true,
+			expectErr: false,
+		},
+		{
+			name: "db_query_error",
+			// Simula error de ejecución de query
+			mockSetup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery("SELECT e.id, e.id_card_number,").WillReturnError(errors.New("fail"))
+			},
+			wantEmpty: true,
+			expectErr: true,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Crea un sqlmock y una db falsa
+			db, mock, err := sqlmock.New()
+			require.NoError(t, err)
+			defer db.Close()
+			tc.mockSetup(mock)
+
+			repository := repo.NewInboundOrderRepository(db)
+			res, err := repository.ReportAll(context.Background())
+			if tc.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				if tc.wantEmpty {
+					require.Empty(t, res)
+				} else {
+					require.NotEmpty(t, res)
+				}
+			}
+			// Verifica que no quedó ninguna query/fila pendiente en el mock
+			require.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+}
+
+// Test unitario para ReportByID: reporte de inbound orders de un solo empleado
+func TestInboundOrderRepository_ReportByID(t *testing.T) {
+	testCases := []struct {
+		name       string
+		employeeID int
+		mockSetup  func(sqlmock.Sqlmock)
+		wantNil    bool
+		expectErr  bool
+	}{
+		{
+			name:       "report_by_id_ok",
+			employeeID: 1,
+			// Devuelve datos para el empleado 1
+			mockSetup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery("SELECT e.id, e.id_card_number,").
+					WithArgs(1).
+					WillReturnRows(
+						sqlmock.NewRows([]string{
+							"id", "id_card_number", "first_name", "last_name", "warehouse_id", "inbound_orders_count"}).
+							AddRow(1, "CARDID", "Juan", "Tester", 1, 9))
+			},
+			wantNil:   false,
+			expectErr: false,
+		},
+		{
+			name:       "not_found",
+			employeeID: 2,
+			// Simula no encontrar ese empleado (sql.ErrNoRows)
+			mockSetup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery("SELECT e.id, e.id_card_number,").
+					WithArgs(2).
+					WillReturnError(sql.ErrNoRows)
+			},
+			wantNil:   true,
+			expectErr: true,
+		},
+		{
+			name:       "scan_error",
+			employeeID: 3,
+			// Simula un error genérico
+			mockSetup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery("SELECT e.id, e.id_card_number,").
+					WithArgs(3).
+					WillReturnError(errors.New("fail"))
+			},
+			wantNil:   true,
+			expectErr: true,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			db, mock, err := sqlmock.New()
+			require.NoError(t, err)
+			defer db.Close()
+			tc.mockSetup(mock)
+			repository := repo.NewInboundOrderRepository(db)
+			res, err := repository.ReportByID(context.Background(), tc.employeeID)
+			if tc.expectErr {
+				require.Error(t, err)
+				require.Nil(t, res)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, res)
+			}
+			require.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+}

--- a/internal/repository/inbound_order/inbound_orders_create_test.go
+++ b/internal/repository/inbound_order/inbound_orders_create_test.go
@@ -1,0 +1,114 @@
+package repository_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/require"
+	repo "github.com/varobledo_meli/W17-G10-Bootcamp.git/internal/repository/inbound_order"
+	models "github.com/varobledo_meli/W17-G10-Bootcamp.git/pkg/models/inbound_order"
+	"github.com/varobledo_meli/W17-G10-Bootcamp.git/testhelpers"
+)
+
+// Test unitario para el método Create del repositorio de inbound_order usando sqlmock y helpers DRY
+func TestInboundOrderRepository_Create(t *testing.T) {
+	testCases := []struct {
+		name      string
+		input     *models.InboundOrder
+		mockSetup func(sqlmock.Sqlmock)
+		expectErr bool
+		wantCode  string // para validar el tipo/código del error si aplica
+	}{
+		{
+			name: "insert_ok",
+			// Datos dummy con helper
+			input: testhelpers.CreateExpectedInboundOrder(0),
+			// Simula un insert exitoso con ret id 10
+			mockSetup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectExec("INSERT INTO inbound_orders").
+					WithArgs("2024-06-01", "INV001", 1, 10, 1).
+					WillReturnResult(sqlmock.NewResult(10, 1))
+			},
+			expectErr: false,
+		},
+		{
+			name: "unique_violation",
+			// Simula conflicto de unique/duplicate en order_number (MySQL error 1062)
+			input: testhelpers.CreateExpectedInboundOrder(0),
+			mockSetup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectExec("INSERT INTO inbound_orders").
+					WithArgs("2024-06-01", "INV001", 1, 10, 1).
+					WillReturnError(&mysql.MySQLError{Number: 1062, Message: "dup"})
+			},
+			expectErr: true,
+			wantCode:  "CONFLICT",
+		},
+		{
+			name: "fk_violation",
+			// Simula violación de clave foránea (MySQL error 1452) en cualquier FK referenciada
+			input: testhelpers.CreateExpectedInboundOrder(0),
+			mockSetup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectExec("INSERT INTO inbound_orders").
+					WithArgs("2024-06-01", "INV001", 1, 10, 1).
+					WillReturnError(&mysql.MySQLError{Number: 1452, Message: "fk fail"})
+			},
+			expectErr: true,
+			wantCode:  "NOT_FOUND",
+		},
+		{
+			name: "generic_error",
+			// Simula un error genérico de la bd no manejado especialmente
+			input: testhelpers.CreateExpectedInboundOrder(0),
+			mockSetup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectExec("INSERT INTO inbound_orders").
+					WithArgs("2024-06-01", "INV001", 1, 10, 1).
+					WillReturnError(errors.New("generic"))
+			},
+			expectErr: true,
+		},
+		{
+			name: "error_last_insert_id",
+			// Simula error al obtener el último insert id después del insert (mal driver)
+			input: testhelpers.CreateExpectedInboundOrder(0),
+			mockSetup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectExec("INSERT INTO inbound_orders").
+					WithArgs("2024-06-01", "INV001", 1, 10, 1).
+					WillReturnResult(sqlmock.NewErrorResult(errors.New("err")))
+			},
+			expectErr: true,
+			wantCode:  "INTERNAL",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Instancia una DB mockeada con sqlmock
+			db, mock, err := sqlmock.New()
+			require.NoError(t, err)
+			defer db.Close()
+			// Configura el mock según el caso
+			tc.mockSetup(mock)
+			repository := repo.NewInboundOrderRepository(db)
+			ctx := context.Background()
+			// Ejecuta el método Create
+			res, err := repository.Create(ctx, tc.input)
+			if tc.expectErr {
+				require.Error(t, err)
+				require.Nil(t, res)
+				// Si aplica, chequea el código en el mensaje de error
+				if tc.wantCode != "" {
+					require.Contains(t, err.Error(), tc.wantCode)
+				}
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, res)
+				require.NotZero(t, res.ID)
+			}
+			// Valida que todas las expectativas del mock se hayan cumplido
+			require.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+}

--- a/mocks/inbound_order/inbound_order_repository_mock.go
+++ b/mocks/inbound_order/inbound_order_repository_mock.go
@@ -6,6 +6,7 @@ import (
 	models "github.com/varobledo_meli/W17-G10-Bootcamp.git/pkg/models/inbound_order"
 )
 
+// Interfaz del repository
 type InboundOrderRepositoryMock struct {
 	MockCreate              func(ctx context.Context, o *models.InboundOrder) (*models.InboundOrder, error)
 	MockExistsByOrderNumber func(ctx context.Context, orderNumber string) (bool, error)


### PR DESCRIPTION
**Descripción**

- Se agregaron tests unitarios utilizando sqlmock para el repositorio de inbound_orders, cubriendo los métodos principales (Create, ExistsByOrderNumber, ReportAll y ReportByID), y validando tanto los escenarios de éxito como los posibles errores de ejecución y restricciones de base de datos.
- Los tests hacen uso de helpers centralizados (testhelpers) para mantener los datos de prueba DRY, legibles y consistentes.
- Además, se añadieron comentarios detallados a los tests del repositorio de employees para mejorar la comprensión, facilitar el mantenimiento y el onboarding de nuevos miembros del equipo.