### PR TITLE
feature: added coverage in makefile for employee and inbound_order

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,3 +59,17 @@ cover-seller:
 cover-geography:
 	go test ./internal/service/geography/... ./internal/handler/geography/... ./internal/repository/geography/... -coverprofile=geography_coverage.out && \
 	go tool cover -func=geography_coverage.out
+
+# EMPLOYEE MODULE COVERAGE
+# Runs tests and shows coverage for employee module (service, handler, repository)
+.PHONY: cover-employee
+cover-employee:
+	go test ./internal/service/employee/... ./internal/handler/employee/... ./internal/repository/employee/... -coverprofile=employee_coverage.out && \
+	go tool cover -func=employee_coverage.out
+
+# INBOUND_ORDER MODULE COVERAGE
+# Runs tests and shows coverage for inbound_order module (service, handler, repository)
+.PHONY: cover-inbound_order
+cover-inbound_order:
+	go test ./internal/service/inbound_order/... ./internal/handler/inbound_order/... ./internal/repository/inbound_order/... -coverprofile=inbound_order_coverage.out && \
+	go tool cover -func=inbound_order_coverage.out


### PR DESCRIPTION
**Descripción**

- Se agregaron targets al Makefile para ejecutar de forma sencilla los tests y obtener la cobertura de código (coverage) de los módulos de employee e inbound_order:

  - make cover-employee: ejecuta los tests y muestra el coverage unificado de repository, service y handler para empleados.
  - make cover-inbound_order: ejecuta los tests y muestra el coverage unificado de repository, service y handler para inbound orders.

- Estos comandos permiten a cualquier miembro del equipo chequear rápidamente el porcentaje de cobertura de cada módulo, mejorar la mantenibilidad y facilitar los workflows de integración continua.