### PR TITLE
feature: added test case for report all for inbound_order handler

### DIFF
--- a/internal/handler/inbound_order/inbound_order_read_test.go
+++ b/internal/handler/inbound_order/inbound_order_read_test.go
@@ -54,6 +54,16 @@ func TestInboundOrderHandler_Report(t *testing.T) {
 			wantStatus:  http.StatusNotFound,
 			wantContent: `"not found"`,
 		},
+		{
+			name:    "report_all_no_id",
+			queryID: nil, // Sin parámetro id
+			mockReport: func(ctx context.Context, id *int) (interface{}, error) {
+				// Simula que devuelve varios reportes al no pasar id
+				return testhelpers.CreateInboundOrderReports(), nil
+			},
+			wantStatus:  http.StatusOK,
+			wantContent: `"inbound_orders_count":5`, // cualquier campo representativo de los datos
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
**Descripción:** 
- Se agregó un nuevo caso de test para el handler de inbound_order en el endpoint GET /api/v1/employees/reportInboundOrders, específicamente para validar el comportamiento cuando no se proporciona el parámetro id en la query string.
- Este test garantiza que el handler y la integración con el servicio cumplen la expectativa de negocio cuando se consulta el reporte global, evitando falsos positivos sobre el manejo del parámetro id. Además, se mejora la mantenibilidad y claridad al tener cubiertos explícitamente todos los caminos relevantes del endpoint.