### PR TITLE
test: improve unit test coverage for geography and seller modules

### DIFF
--- a/internal/mappers/seller_test.go
+++ b/internal/mappers/seller_test.go
@@ -1,0 +1,162 @@
+package mappers_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/varobledo_meli/W17-G10-Bootcamp.git/internal/mappers"
+	models "github.com/varobledo_meli/W17-G10-Bootcamp.git/pkg/models/seller"
+)
+
+func TestRequestSellerToSeller(t *testing.T) {
+	cid := 42
+	company := "DemoCompany"
+	address := "Test 555"
+	telephone := "12345"
+	locality := "ABCD"
+
+	tests := []struct {
+		name string
+		in   models.RequestSeller
+		want models.Seller
+	}{
+		{
+			name: "simple mapping",
+			in: models.RequestSeller{
+				Cid:         &cid,
+				CompanyName: &company,
+				Address:     &address,
+				Telephone:   &telephone,
+				LocalityId:  &locality,
+			},
+			want: models.Seller{
+				Id:          0,
+				Cid:         cid,
+				CompanyName: company,
+				Address:     address,
+				Telephone:   telephone,
+				LocalityId:  locality,
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := mappers.RequestSellerToSeller(tc.in)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestToResponseSeller(t *testing.T) {
+	input := models.Seller{
+		Id:          5,
+		Cid:         42,
+		CompanyName: "Company",
+		Address:     "Addr",
+		Telephone:   "Tel",
+		LocalityId:  "Local",
+	}
+	want := models.ResponseSeller{
+		Id:          5,
+		Cid:         42,
+		CompanyName: "Company",
+		Address:     "Addr",
+		Telephone:   "Tel",
+		LocalityId:  "Local",
+	}
+
+	t.Run("returns correct response", func(t *testing.T) {
+		got := mappers.ToResponseSeller(&input)
+		assert.Equal(t, want, got)
+	})
+}
+
+func TestToResponseSellerList(t *testing.T) {
+	input := []models.Seller{
+		{Id: 1, Cid: 1, CompanyName: "A", Address: "B", Telephone: "C", LocalityId: "D"},
+		{Id: 2, Cid: 2, CompanyName: "X", Address: "Y", Telephone: "Z", LocalityId: "W"},
+	}
+	want := []models.ResponseSeller{
+		{Id: 1, Cid: 1, CompanyName: "A", Address: "B", Telephone: "C", LocalityId: "D"},
+		{Id: 2, Cid: 2, CompanyName: "X", Address: "Y", Telephone: "Z", LocalityId: "W"},
+	}
+
+	t.Run("converts list", func(t *testing.T) {
+		got := mappers.ToResponseSellerList(input)
+		assert.Equal(t, want, got)
+	})
+}
+
+func TestApplySellerPatch(t *testing.T) {
+	base := models.Seller{
+		Id:          100,
+		Cid:         11,
+		CompanyName: "OldComp",
+		Address:     "OldStreet",
+		Telephone:   "111",
+		LocalityId:  "LOC",
+	}
+	patchCid := 22
+	patchCompany := "NewComp"
+	patchAddress := "NewStreet"
+	patchTelephone := "222"
+	patchLocality := "NEWLOC"
+
+	tests := []struct {
+		name   string
+		patch  models.RequestSeller
+		expect models.Seller
+	}{
+		{
+			name:  "patch cid",
+			patch: models.RequestSeller{Cid: &patchCid},
+			expect: models.Seller{
+				Id:          100,
+				Cid:         patchCid,
+				CompanyName: "OldComp",
+				Address:     "OldStreet",
+				Telephone:   "111",
+				LocalityId:  "LOC",
+			},
+		},
+		{
+			name:  "patch company",
+			patch: models.RequestSeller{CompanyName: &patchCompany},
+			expect: models.Seller{
+				Id:          100,
+				Cid:         11,
+				CompanyName: patchCompany,
+				Address:     "OldStreet",
+				Telephone:   "111",
+				LocalityId:  "LOC",
+			},
+		},
+		{
+			name: "patch all",
+			patch: models.RequestSeller{
+				Cid:         &patchCid,
+				CompanyName: &patchCompany,
+				Address:     &patchAddress,
+				Telephone:   &patchTelephone,
+				LocalityId:  &patchLocality,
+			},
+			expect: models.Seller{
+				Id:          100,
+				Cid:         patchCid,
+				CompanyName: patchCompany,
+				Address:     patchAddress,
+				Telephone:   patchTelephone,
+				LocalityId:  patchLocality,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Reset to base value for each run
+			original := base
+			mappers.ApplySellerPatch(&original, &tc.patch)
+			assert.Equal(t, tc.expect, original)
+		})
+	}
+}

--- a/internal/repository/geography/geography_test.go
+++ b/internal/repository/geography/geography_test.go
@@ -1,0 +1,67 @@
+package repository_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+
+	geography "github.com/varobledo_meli/W17-G10-Bootcamp.git/internal/repository/geography"
+)
+
+func TestGeographyRepository_BeginTx(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	assert.NoError(t, err)
+	defer db.Close()
+	repo := geography.NewGeographyRepository(db)
+
+	mock.ExpectBegin()
+	tx, err := repo.BeginTx(context.Background())
+	assert.NoError(t, err)
+	assert.NotNil(t, tx)
+	_ = tx.Rollback() // aseguramos cleanup de la tx
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestGeographyRepository_CommitTx(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	assert.NoError(t, err)
+	defer db.Close()
+	repo := geography.NewGeographyRepository(db)
+
+	mock.ExpectBegin()
+	tx, err := db.Begin()
+	assert.NoError(t, err)
+	mock.ExpectCommit()
+
+	err = repo.CommitTx(tx)
+	assert.NoError(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestGeographyRepository_RollbackTx(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	assert.NoError(t, err)
+	defer db.Close()
+	repo := geography.NewGeographyRepository(db)
+
+	mock.ExpectBegin()
+	tx, err := db.Begin()
+	assert.NoError(t, err)
+	mock.ExpectRollback()
+
+	err = repo.RollbackTx(tx)
+	assert.NoError(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestGeographyRepository_GetDB(t *testing.T) {
+	db, _, err := sqlmock.New()
+	assert.NoError(t, err)
+	defer db.Close()
+	repo := geography.NewGeographyRepository(db)
+
+	dbReturned := repo.GetDB()
+	assert.Equal(t, db, dbReturned)
+}

--- a/internal/service/geography/geography_count_test.go
+++ b/internal/service/geography/geography_count_test.go
@@ -1,0 +1,158 @@
+package service_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	service "github.com/varobledo_meli/W17-G10-Bootcamp.git/internal/service/geography"
+	mocks "github.com/varobledo_meli/W17-G10-Bootcamp.git/mocks/geography"
+	models "github.com/varobledo_meli/W17-G10-Bootcamp.git/pkg/models/geography"
+)
+
+func TestGeographyService_CountSellersGroupedByLocality(t *testing.T) {
+	tests := []struct {
+		name     string
+		mockRepo func() *mocks.GeographyRepositoryMock
+		wantErr  bool
+		wantMsg  string
+		wantResp []models.ResponseLocalitySellers
+	}{
+		{
+			name: "success",
+			mockRepo: func() *mocks.GeographyRepositoryMock {
+				mock := &mocks.GeographyRepositoryMock{}
+				mock.FuncCountSellersGroupedByLocality = func(ctx context.Context) ([]models.ResponseLocalitySellers, error) {
+					return []models.ResponseLocalitySellers{
+						{LocalityId: "101", LocalityName: "CABA", SellersCount: 10},
+						{LocalityId: "102", LocalityName: "Córdoba", SellersCount: 5},
+					}, nil
+				}
+				return mock
+			},
+			wantErr: false,
+			wantResp: []models.ResponseLocalitySellers{
+				{LocalityId: "101", LocalityName: "CABA", SellersCount: 10},
+				{LocalityId: "102", LocalityName: "Córdoba", SellersCount: 5},
+			},
+		},
+		{
+			name: "repo error",
+			mockRepo: func() *mocks.GeographyRepositoryMock {
+				mock := &mocks.GeographyRepositoryMock{}
+				mock.FuncCountSellersGroupedByLocality = func(ctx context.Context) ([]models.ResponseLocalitySellers, error) {
+					return nil, errors.New("repo failure")
+				}
+				return mock
+			},
+			wantErr: true,
+			wantMsg: "repo failure",
+		},
+		{
+			name: "repo returns nil slice, nil error",
+			mockRepo: func() *mocks.GeographyRepositoryMock {
+				mock := &mocks.GeographyRepositoryMock{}
+				mock.FuncCountSellersGroupedByLocality = func(ctx context.Context) ([]models.ResponseLocalitySellers, error) {
+					return nil, nil
+				}
+				return mock
+			},
+			wantErr:  false,
+			wantResp: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := tt.mockRepo()
+			srv := service.NewGeographyService(repo)
+			resp, err := srv.CountSellersGroupedByLocality(context.Background())
+
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.wantMsg != "" {
+					require.Contains(t, err.Error(), tt.wantMsg)
+				}
+				require.Nil(t, resp)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.wantResp, resp)
+			}
+		})
+	}
+}
+
+func TestGeographyService_CountSellersByLocality(t *testing.T) {
+	tests := []struct {
+		name     string
+		id       string
+		mockRepo func() *mocks.GeographyRepositoryMock
+		wantErr  bool
+		wantMsg  string
+		wantResp *models.ResponseLocalitySellers
+	}{
+		{
+			name: "success",
+			id:   "101",
+			mockRepo: func() *mocks.GeographyRepositoryMock {
+				mock := &mocks.GeographyRepositoryMock{}
+				mock.FuncCountSellersByLocality = func(ctx context.Context, id string) (*models.ResponseLocalitySellers, error) {
+					return &models.ResponseLocalitySellers{
+						LocalityId: "101", LocalityName: "CABA", SellersCount: 20,
+					}, nil
+				}
+				return mock
+			},
+			wantErr: false,
+			wantResp: &models.ResponseLocalitySellers{
+				LocalityId: "101", LocalityName: "CABA", SellersCount: 20,
+			},
+		},
+		{
+			name: "repo error",
+			id:   "666",
+			mockRepo: func() *mocks.GeographyRepositoryMock {
+				mock := &mocks.GeographyRepositoryMock{}
+				mock.FuncCountSellersByLocality = func(ctx context.Context, id string) (*models.ResponseLocalitySellers, error) {
+					return nil, errors.New("no sellers")
+				}
+				return mock
+			},
+			wantErr: true,
+			wantMsg: "no sellers",
+		},
+		{
+			name: "repo returns nil,nil",
+			id:   "999",
+			mockRepo: func() *mocks.GeographyRepositoryMock {
+				mock := &mocks.GeographyRepositoryMock{}
+				mock.FuncCountSellersByLocality = func(ctx context.Context, id string) (*models.ResponseLocalitySellers, error) {
+					return nil, nil
+				}
+				return mock
+			},
+			wantErr:  false,
+			wantResp: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := tt.mockRepo()
+			srv := service.NewGeographyService(repo)
+			resp, err := srv.CountSellersByLocality(context.Background(), tt.id)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.wantMsg != "" {
+					require.Contains(t, err.Error(), tt.wantMsg)
+				}
+				require.Nil(t, resp)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.wantResp, resp)
+			}
+		})
+	}
+}

--- a/internal/validators/geography_test.go
+++ b/internal/validators/geography_test.go
@@ -1,0 +1,99 @@
+package validators_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/varobledo_meli/W17-G10-Bootcamp.git/internal/validators"
+	"github.com/varobledo_meli/W17-G10-Bootcamp.git/pkg/api/apperrors"
+	models "github.com/varobledo_meli/W17-G10-Bootcamp.git/pkg/models/geography"
+)
+
+func TestValidateGeographyPost(t *testing.T) {
+	validPostal := "1234"
+	validCountry := "Argentina"
+	validProvince := "Buenos Aires"
+	validLocality := "CABA"
+
+	cases := []struct {
+		name      string
+		input     models.RequestGeography
+		wantError bool
+		wantMsg   string
+	}{
+		{
+			name: "all valid",
+			input: models.RequestGeography{
+				Id:           strPtr(validPostal),
+				CountryName:  strPtr(validCountry),
+				ProvinceName: strPtr(validProvince),
+				LocalityName: strPtr(validLocality),
+			},
+			wantError: false,
+		},
+		{
+			name:      "all nil",
+			input:     models.RequestGeography{},
+			wantError: true,
+			wantMsg:   "Id (Postal Code) is required and cannot be empty.",
+		},
+		{
+			name: "postal empty",
+			input: models.RequestGeography{
+				Id:           strPtr(""),
+				CountryName:  strPtr(validCountry),
+				ProvinceName: strPtr(validProvince),
+				LocalityName: strPtr(validLocality),
+			},
+			wantError: true,
+			wantMsg:   "Id (Postal Code) is required and cannot be empty.",
+		},
+		{
+			name: "country empty",
+			input: models.RequestGeography{
+				Id:           strPtr(validPostal),
+				CountryName:  strPtr(""),
+				ProvinceName: strPtr(validProvince),
+				LocalityName: strPtr(validLocality),
+			},
+			wantError: true,
+			wantMsg:   "Country Name is required and cannot be empty.",
+		},
+		{
+			name: "province empty",
+			input: models.RequestGeography{
+				Id:           strPtr(validPostal),
+				CountryName:  strPtr(validCountry),
+				ProvinceName: strPtr(""),
+				LocalityName: strPtr(validLocality),
+			},
+			wantError: true,
+			wantMsg:   "Pronvice Name is required and cannot be empty.",
+		},
+		{
+			name: "locality empty",
+			input: models.RequestGeography{
+				Id:           strPtr(validPostal),
+				CountryName:  strPtr(validCountry),
+				ProvinceName: strPtr(validProvince),
+				LocalityName: strPtr(""),
+			},
+			wantError: true,
+			wantMsg:   "Locality Name is required and cannot be empty.",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validators.ValidateGeographyPost(tc.input)
+			if tc.wantError {
+				assert.Error(t, err)
+				if appErr, ok := err.(*apperrors.AppError); ok && tc.wantMsg != "" {
+					assert.Equal(t, tc.wantMsg, appErr.Message)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/internal/validators/seller_test.go
+++ b/internal/validators/seller_test.go
@@ -1,0 +1,263 @@
+package validators_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/varobledo_meli/W17-G10-Bootcamp.git/internal/validators"
+	"github.com/varobledo_meli/W17-G10-Bootcamp.git/pkg/api/apperrors"
+	models "github.com/varobledo_meli/W17-G10-Bootcamp.git/pkg/models/seller"
+)
+
+func TestValidateSellerPost(t *testing.T) {
+	validCid := 1
+	validCompany := "Company"
+	validAddress := "Address"
+	validTel := "123456"
+	validLoc := "10"
+
+	cases := []struct {
+		name      string
+		input     models.RequestSeller
+		wantError bool
+		wantMsg   string
+	}{
+		{
+			name: "valid",
+			input: models.RequestSeller{
+				Cid:         &validCid,
+				CompanyName: &validCompany,
+				Address:     &validAddress,
+				Telephone:   &validTel,
+				LocalityId:  &validLoc,
+			},
+			wantError: false,
+		},
+		{
+			name:      "all missing",
+			input:     models.RequestSeller{},
+			wantError: true,
+			wantMsg:   "Cid is required and must be greater than 0.",
+		},
+		{
+			name: "invalid Cid",
+			input: models.RequestSeller{
+				Cid:         intPtr(0),
+				CompanyName: &validCompany,
+				Address:     &validAddress,
+				Telephone:   &validTel,
+				LocalityId:  &validLoc,
+			},
+			wantError: true,
+			wantMsg:   "Cid is required and must be greater than 0.",
+		},
+		{
+			name: "empty company",
+			input: models.RequestSeller{
+				Cid:         &validCid,
+				CompanyName: strPtr(""),
+				Address:     &validAddress,
+				Telephone:   &validTel,
+				LocalityId:  &validLoc,
+			},
+			wantError: true,
+			wantMsg:   "CompanyName is required and cannot be empty.",
+		},
+		{
+			name: "empty address",
+			input: models.RequestSeller{
+				Cid:         &validCid,
+				CompanyName: &validCompany,
+				Address:     strPtr(""),
+				Telephone:   &validTel,
+				LocalityId:  &validLoc,
+			},
+			wantError: true,
+			wantMsg:   "Address is required and cannot be empty.",
+		},
+		{
+			name: "empty telephone",
+			input: models.RequestSeller{
+				Cid:         &validCid,
+				CompanyName: &validCompany,
+				Address:     &validAddress,
+				Telephone:   strPtr(""),
+				LocalityId:  &validLoc,
+			},
+			wantError: true,
+			wantMsg:   "Telephone is required and cannot be empty.",
+		},
+		{
+			name: "empty locality",
+			input: models.RequestSeller{
+				Cid:         &validCid,
+				CompanyName: &validCompany,
+				Address:     &validAddress,
+				Telephone:   &validTel,
+				LocalityId:  strPtr(""),
+			},
+			wantError: true,
+			wantMsg:   "Locality is required and must be greater than 0.",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validators.ValidateSellerPost(tc.input)
+			if tc.wantError {
+				assert.Error(t, err)
+				if appErr, ok := err.(*apperrors.AppError); ok && tc.wantMsg != "" {
+					assert.Equal(t, tc.wantMsg, appErr.Message)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateSellerPatch(t *testing.T) {
+	validCid := 1
+
+	cases := []struct {
+		name      string
+		input     models.RequestSeller
+		wantError bool
+		wantMsg   string
+	}{
+		{
+			name:      "all nil",
+			input:     models.RequestSeller{},
+			wantError: false,
+		},
+		{
+			name: "valid one field",
+			input: models.RequestSeller{
+				Cid: &validCid,
+			},
+			wantError: false,
+		},
+		{
+			name: "invalid cid",
+			input: models.RequestSeller{
+				Cid: intPtr(0),
+			},
+			wantError: true,
+			wantMsg:   "Cid must be greater than 0.",
+		},
+		{
+			name: "empty company",
+			input: models.RequestSeller{
+				CompanyName: strPtr(""),
+			},
+			wantError: true,
+			wantMsg:   "CompanyName cannot be empty.",
+		},
+		{
+			name: "empty address",
+			input: models.RequestSeller{
+				Address: strPtr(""),
+			},
+			wantError: true,
+			wantMsg:   "Address cannot be empty.",
+		},
+		{
+			name: "empty telephone",
+			input: models.RequestSeller{
+				Telephone: strPtr(""),
+			},
+			wantError: true,
+			wantMsg:   "Telephone cannot be empty.",
+		},
+		{
+			name: "empty locality",
+			input: models.RequestSeller{
+				LocalityId: strPtr(""),
+			},
+			wantError: true,
+			wantMsg:   "Locality cannot be empty.",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validators.ValidateSellerPatch(tc.input)
+			if tc.wantError {
+				assert.Error(t, err)
+				if appErr, ok := err.(*apperrors.AppError); ok && tc.wantMsg != "" {
+					assert.Equal(t, tc.wantMsg, appErr.Message)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateSellerPatchNotEmpty(t *testing.T) {
+	validCid := 1
+	validCompany := "Company"
+	validAddress := "Some address"
+	validTel := "1234"
+	validLoc := "10"
+
+	cases := []struct {
+		name      string
+		input     models.RequestSeller
+		wantError bool
+		wantMsg   string
+	}{
+		{
+			name:      "all nil fields",
+			input:     models.RequestSeller{},
+			wantError: true,
+			wantMsg:   "at least one field is required to be updated.",
+		},
+		{
+			name:      "cid only",
+			input:     models.RequestSeller{Cid: &validCid},
+			wantError: false,
+		},
+		{
+			name:      "company only",
+			input:     models.RequestSeller{CompanyName: &validCompany},
+			wantError: false,
+		},
+		{
+			name:      "address only",
+			input:     models.RequestSeller{Address: &validAddress},
+			wantError: false,
+		},
+		{
+			name:      "telephone only",
+			input:     models.RequestSeller{Telephone: &validTel},
+			wantError: false,
+		},
+		{
+			name:      "locality only",
+			input:     models.RequestSeller{LocalityId: &validLoc},
+			wantError: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validators.ValidateSellerPatchNotEmpty(tc.input)
+			if tc.wantError {
+				assert.Error(t, err)
+				if appErr, ok := err.(*apperrors.AppError); ok && tc.wantMsg != "" {
+					assert.Equal(t, tc.wantMsg, appErr.Message)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// helpers
+func strPtr(s string) *string {
+	return &s
+}
+func intPtr(i int) *int {
+	return &i
+}


### PR DESCRIPTION
This pull request significantly improves the unit test coverage across multiple modules, focusing on the `geography`, `seller`, and related service, repository, mapper, and validator packages. The following has been added:

- Comprehensive table-driven tests for seller mappers (`RequestSellerToSeller`, `ApplySellerPatch`, etc.).
- Full test coverage for the geography repository database methods (`BeginTx`, `CommitTx`, `RollbackTx`, `GetDB`) using sqlmock.
- Extensive tests for the validators covering all branches and error messages for both seller and geography request models.
- New tests for the geography service's `CountSellersGroupedByLocality` and `CountSellersByLocality` methods, including success paths, error handling, and edge cases.
- All new tests follow project conventions and use `stretchr/testify` for assertions and mocks for repository/service layer isolation.

These tests add no breaking changes and help ensure repo stability while refactoring or extending business logic in the future.