### PR TITLE
test: add unit tests for section and product batches mappers and validators

### DIFF
--- a/internal/mappers/product_batches_test.go
+++ b/internal/mappers/product_batches_test.go
@@ -1,0 +1,79 @@
+package mappers_test
+
+import (
+	"github.com/stretchr/testify/require"
+	"github.com/varobledo_meli/W17-G10-Bootcamp.git/internal/mappers"
+	models "github.com/varobledo_meli/W17-G10-Bootcamp.git/pkg/models/product_batches"
+	"github.com/varobledo_meli/W17-G10-Bootcamp.git/testhelpers"
+	"testing"
+)
+
+func TestRequestToProductBatch(t *testing.T) {
+	t.Run("maps all fields from PostProductBatches to ProductBatches", func(t *testing.T) {
+		req := testhelpers.DummyPostProductBatch(1)
+		expected := models.ProductBatches{
+			BatchNumber:        req.BatchNumber,
+			CurrentQuantity:    *req.CurrentQuantity,
+			CurrentTemperature: *req.CurrentTemperature,
+			DueDate:            req.DueDate,
+			InitialQuantity:    *req.InitialQuantity,
+			ManufacturingDate:  req.ManufacturingDate,
+			ManufacturingHour:  req.ManufacturingHour,
+			MinimumTemperature: *req.MinimumTemperature,
+			ProductId:          req.ProductId,
+			SectionId:          req.SectionId,
+		}
+
+		got := mappers.RequestToProductBatch(req)
+		require.Equal(t, expected, got)
+	})
+
+	t.Run("panics if CurrentQuantity is nil", func(t *testing.T) {
+		req := testhelpers.DummyPostProductBatch(1)
+		req.CurrentQuantity = nil
+		require.Panics(t, func() {
+			_ = mappers.RequestToProductBatch(req)
+		})
+	})
+
+	t.Run("panics if CurrentTemperature is nil", func(t *testing.T) {
+		req := testhelpers.DummyPostProductBatch(1)
+		req.CurrentTemperature = nil
+		require.Panics(t, func() {
+			_ = mappers.RequestToProductBatch(req)
+		})
+	})
+
+	t.Run("panics if InitialQuantity is nil", func(t *testing.T) {
+		req := testhelpers.DummyPostProductBatch(1)
+		req.InitialQuantity = nil
+		require.Panics(t, func() {
+			_ = mappers.RequestToProductBatch(req)
+		})
+	})
+
+	t.Run("panics if MinimumTemperature is nil", func(t *testing.T) {
+		req := testhelpers.DummyPostProductBatch(1)
+		req.MinimumTemperature = nil
+		require.Panics(t, func() {
+			_ = mappers.RequestToProductBatch(req)
+		})
+	})
+}
+
+func TestProductBatchesToResponse(t *testing.T) {
+	t.Run("maps all fields from ProductBatches to ProductBatchesResponse", func(t *testing.T) {
+		input := testhelpers.DummyProductBatch(1)
+		expected := testhelpers.DummyResponseProductBatch(1) // Si tienes un helper para esto
+
+		got := mappers.ProductBatchesToResponse(input)
+		require.Equal(t, expected, got)
+	})
+
+	t.Run("maps zero values as is", func(t *testing.T) {
+		input := models.ProductBatches{}
+		expected := models.ProductBatchesResponse{}
+		got := mappers.ProductBatchesToResponse(input)
+		require.Equal(t, expected, got)
+	})
+}

--- a/internal/mappers/section_test.go
+++ b/internal/mappers/section_test.go
@@ -1,0 +1,110 @@
+package mappers_test
+
+import (
+	"github.com/stretchr/testify/require"
+	"github.com/varobledo_meli/W17-G10-Bootcamp.git/internal/mappers"
+	models "github.com/varobledo_meli/W17-G10-Bootcamp.git/pkg/models/section"
+	"github.com/varobledo_meli/W17-G10-Bootcamp.git/testhelpers"
+	"testing"
+)
+
+func TestRequestSectionToSection(t *testing.T) {
+	t.Run("maps all fields from PostSection (request) to Section (model)", func(t *testing.T) {
+		// Given
+		in := testhelpers.DummySectionPost(1)
+		want := models.Section{
+			SectionNumber:      in.SectionNumber,
+			CurrentTemperature: *in.CurrentTemperature,
+			MinimumTemperature: *in.MinimumTemperature,
+			CurrentCapacity:    in.CurrentCapacity,
+			MinimumCapacity:    in.MinimumCapacity,
+			MaximumCapacity:    in.MaximumCapacity,
+			WarehouseId:        in.WarehouseId,
+			ProductTypeId:      in.ProductTypeId,
+		}
+
+		// When
+		got := mappers.RequestSectionToSection(in)
+
+		// Then
+		require.Equal(t, want, got)
+	})
+
+	t.Run("panics if CurrentTemperature is nil", func(t *testing.T) {
+		in := testhelpers.DummySectionPost(1)
+		in.CurrentTemperature = nil
+
+		require.Panics(t, func() {
+			_ = mappers.RequestSectionToSection(in)
+		})
+	})
+}
+
+func TestSectionToResponseSection(t *testing.T) {
+	t.Run("maps all fields from Section (model) to ResponseSection", func(t *testing.T) {
+		in := testhelpers.DummySection(1)
+		want := testhelpers.DummyResponseSection(1)
+
+		got := mappers.SectionToResponseSection(in)
+
+		require.Equal(t, want, got)
+	})
+}
+
+func TestApplySectionPatch(t *testing.T) {
+	type args struct {
+		patch    models.PatchSection
+		original models.Section
+		expect   models.Section
+	}
+
+	tests := []args{
+		{
+			patch: models.PatchSection{
+				SectionNumber:      testhelpers.IntPtr(900),
+				CurrentTemperature: testhelpers.Float64Ptr(99.5),
+				CurrentCapacity:    testhelpers.IntPtr(888),
+				MaximumCapacity:    testhelpers.IntPtr(5000),
+				MinimumCapacity:    testhelpers.IntPtr(111),
+				MinimumTemperature: testhelpers.Float64Ptr(42.2),
+				ProductTypeId:      testhelpers.IntPtr(77),
+				WarehouseId:        testhelpers.IntPtr(66),
+			},
+			original: testhelpers.DummySection(1),
+			expect: models.Section{
+				Id:                 1,
+				SectionNumber:      900,
+				CurrentTemperature: 99.5,
+				MinimumTemperature: 42.2,
+				CurrentCapacity:    888,
+				MinimumCapacity:    111,
+				MaximumCapacity:    5000,
+				ProductTypeId:      77,
+				WarehouseId:        66,
+			},
+		},
+		{
+			patch: func() models.PatchSection {
+				ps := models.PatchSection{}
+				ps.CurrentTemperature = testhelpers.Float64Ptr(1234)
+				return ps
+			}(),
+			original: testhelpers.DummySection(1),
+			expect:   func() models.Section { s := testhelpers.DummySection(1); s.CurrentTemperature = 1234; return s }(),
+		},
+		// Caso: patch vacío no cambia nada
+		{
+			patch:    models.PatchSection{},
+			original: testhelpers.DummySection(1),
+			expect:   testhelpers.DummySection(1),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run("patch should update correct fields", func(t *testing.T) {
+			orig := tt.original
+			mappers.ApplySectionPatch(tt.patch, &orig)
+			require.Equal(t, tt.expect, orig)
+		})
+	}
+}

--- a/internal/validators/product_batches_test.go
+++ b/internal/validators/product_batches_test.go
@@ -1,0 +1,101 @@
+package validators_test
+
+import (
+	"github.com/stretchr/testify/require"
+	"github.com/varobledo_meli/W17-G10-Bootcamp.git/internal/validators"
+	"github.com/varobledo_meli/W17-G10-Bootcamp.git/pkg/api/apperrors"
+	models "github.com/varobledo_meli/W17-G10-Bootcamp.git/pkg/models/product_batches"
+	"testing"
+	"time"
+)
+
+func intPtr(v int) *int             { return &v }
+func float64Ptr(v float64) *float64 { return &v }
+
+func validPostProductBatch() models.PostProductBatches {
+	return models.PostProductBatches{
+		BatchNumber:        123,
+		CurrentQuantity:    intPtr(10),
+		CurrentTemperature: float64Ptr(5.5),
+		DueDate:            time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+		InitialQuantity:    intPtr(20),
+		ManufacturingDate:  time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC),
+		ManufacturingHour:  12,
+		MinimumTemperature: float64Ptr(1.2),
+		ProductId:          1,
+		SectionId:          2,
+	}
+}
+
+func TestValidateProductBatchPost(t *testing.T) {
+	testCases := []struct {
+		name    string
+		input   models.PostProductBatches
+		wantMsg string
+	}{
+		{
+			name:    "valid product batch returns nil",
+			input:   validPostProductBatch(),
+			wantMsg: "",
+		},
+		{
+			name: "fails if a required int field is 0",
+			input: func() models.PostProductBatches {
+				pb := validPostProductBatch()
+				pb.BatchNumber = 0
+				return pb
+			}(),
+			wantMsg: "All fields are required",
+		},
+		{
+			name: "fails if a required pointer field is nil",
+			input: func() models.PostProductBatches {
+				pb := validPostProductBatch()
+				pb.CurrentQuantity = nil
+				return pb
+			}(),
+			wantMsg: "All fields are required",
+		},
+		{
+			name: "fails if date is zero (due date)",
+			input: func() models.PostProductBatches {
+				pb := validPostProductBatch()
+				pb.DueDate = time.Time{}
+				return pb
+			}(),
+			wantMsg: "All fields are required",
+		},
+		{
+			name: "fails if current quantity is negative",
+			input: func() models.PostProductBatches {
+				pb := validPostProductBatch()
+				pb.CurrentQuantity = intPtr(-1)
+				return pb
+			}(),
+			wantMsg: "Quantity values cannot be negative.",
+		},
+		{
+			name: "fails if initial quantity is negative",
+			input: func() models.PostProductBatches {
+				pb := validPostProductBatch()
+				pb.InitialQuantity = intPtr(-2)
+				return pb
+			}(),
+			wantMsg: "Quantity values cannot be negative.",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validators.ValidateProductBatchPost(tc.input)
+			if tc.wantMsg == "" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				appErr, ok := err.(*apperrors.AppError)
+				require.True(t, ok)
+				require.Contains(t, appErr.Message, tc.wantMsg)
+			}
+		})
+	}
+}

--- a/internal/validators/section_test.go
+++ b/internal/validators/section_test.go
@@ -1,0 +1,166 @@
+package validators_test
+
+import (
+	"github.com/stretchr/testify/require"
+	"github.com/varobledo_meli/W17-G10-Bootcamp.git/internal/validators"
+	"github.com/varobledo_meli/W17-G10-Bootcamp.git/pkg/api/apperrors"
+	section "github.com/varobledo_meli/W17-G10-Bootcamp.git/pkg/models/section"
+	"github.com/varobledo_meli/W17-G10-Bootcamp.git/testhelpers"
+	"testing"
+)
+
+func TestValidateSectionRequest(t *testing.T) {
+	testCases := []struct {
+		name       string
+		input      section.PostSection
+		wantErrMsg string
+	}{
+		{
+			name:       "valid section returns nil error",
+			input:      testhelpers.DummySectionPost(1),
+			wantErrMsg: "",
+		},
+		{
+			name: "fails if a required int field is zero",
+			input: func() section.PostSection {
+				ps := testhelpers.DummySectionPost(1)
+				ps.SectionNumber = 0
+				return ps
+			}(),
+			wantErrMsg: "All fields are required",
+		},
+		{
+			name: "fails if a required pointer field is nil",
+			input: func() section.PostSection {
+				ps := testhelpers.DummySectionPost(1)
+				ps.MinimumTemperature = nil
+				return ps
+			}(),
+			wantErrMsg: "All fields are required",
+		},
+		{
+			name: "capacity negative (maximum)",
+			input: func() section.PostSection {
+				ps := testhelpers.DummySectionPost(1)
+				ps.MaximumCapacity = -5
+				return ps
+			}(),
+			wantErrMsg: "Capacity values cannot be negative",
+		},
+		{
+			name: "max less than min",
+			input: func() section.PostSection {
+				ps := testhelpers.DummySectionPost(1)
+				ps.MaximumCapacity = 5
+				ps.MinimumCapacity = 10
+				return ps
+			}(),
+			wantErrMsg: "Maximum capacity cannot be less than minimum capacity",
+		},
+		{
+			name: "current exceeds max",
+			input: func() section.PostSection {
+				ps := testhelpers.DummySectionPost(1)
+				ps.CurrentCapacity = 200
+				return ps
+			}(),
+			wantErrMsg: "Current capacity cannot exceed maximum capacity",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validators.ValidateSectionRequest(tc.input)
+			if tc.wantErrMsg == "" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				appErr, ok := err.(*apperrors.AppError)
+				require.True(t, ok)
+				require.Contains(t, appErr.Message, tc.wantErrMsg)
+			}
+		})
+	}
+}
+
+func TestValidateSectionPatch(t *testing.T) {
+	testCases := []struct {
+		name       string
+		input      section.PatchSection
+		wantErrMsg string
+	}{
+		{
+			name:       "valid patch returns nil error",
+			input:      testhelpers.DummySectionPatch(1),
+			wantErrMsg: "",
+		},
+		{
+			name:       "all fields nil should fail",
+			input:      section.PatchSection{},
+			wantErrMsg: "At least one field must be provided",
+		},
+		{
+			name: "negative maximum capacity",
+			input: func() section.PatchSection {
+				ps := testhelpers.DummySectionPatch(1)
+				ps.MaximumCapacity = testhelpers.IntPtr(-5)
+				return ps
+			}(),
+			wantErrMsg: "Maximum capacity cannot be negative",
+		},
+		{
+			name: "negative minimum capacity",
+			input: func() section.PatchSection {
+				ps := testhelpers.DummySectionPatch(1)
+				ps.MinimumCapacity = testhelpers.IntPtr(-10)
+				return ps
+			}(),
+			wantErrMsg: "Minimum capacity cannot be negative",
+		},
+		{
+			name: "negative current capacity",
+			input: func() section.PatchSection {
+				ps := testhelpers.DummySectionPatch(1)
+				ps.CurrentCapacity = testhelpers.IntPtr(-1)
+				return ps
+			}(),
+			wantErrMsg: "Current capacity cannot be negative",
+		},
+		{
+			name: "max less than min",
+			input: func() section.PatchSection {
+				ps := testhelpers.DummySectionPatch(1)
+				max, min := 5, 10
+				ps.MaximumCapacity = &max
+				ps.MinimumCapacity = &min
+				return ps
+			}(),
+			wantErrMsg: "Maximum capacity cannot be less than minimum capacity",
+		},
+		{
+			name: "current greater than max",
+			input: func() section.PatchSection {
+				ps := testhelpers.DummySectionPatch(1)
+				max, curr := 50, 60
+				ps.MaximumCapacity = &max
+				ps.CurrentCapacity = &curr
+				return ps
+			}(),
+			wantErrMsg: "Current capacity cannot exceed maximum capacity",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validators.ValidateSectionPatch(tc.input)
+			if tc.wantErrMsg == "" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				appErr, ok := err.(*apperrors.AppError)
+				require.True(t, ok)
+				require.Contains(t, appErr.Message, tc.wantErrMsg)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds comprehensive unit tests for the mappers and validators in the section and product batches modules.

- Adds table-driven tests covering all logical branches, edge cases, and error handling for:
  - Section mappers (request, response, patch)
  - Product batch mappers
  - Section validators (including patch)
  - Product batch validators
- Ensures safe refactors and improves coverage for business logic functions.
- Uses helpers and dummies to keep tests DRY and easy to maintain.
- Follows Go/chi best practices for project organization, aiming to help the team learn and keep the codebase robust.

These tests will help the team identify any regressions in business rules and provide fast feedback when changing validation or mapping logic.