### PR TITLE
Feat: Add tests for mappers and validators 

### DIFF
--- a/internal/mappers/buyer_test.go
+++ b/internal/mappers/buyer_test.go
@@ -1,0 +1,89 @@
+package mappers_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/varobledo_meli/W17-G10-Bootcamp.git/internal/mappers"
+	models "github.com/varobledo_meli/W17-G10-Bootcamp.git/pkg/models/buyer"
+)
+
+func strPtr(s string) *string { return &s }
+
+func TestRequestBuyerToBuyer_AllFieldsPresent(t *testing.T) {
+	req := models.RequestBuyer{
+		CardNumberId: strPtr("CARD-777"),
+		FirstName:    strPtr("Fede"),
+		LastName:     strPtr("Laguardia"),
+	}
+	got := mappers.RequestBuyerToBuyer(req)
+	assert.Equal(t, "CARD-777", got.CardNumberId)
+	assert.Equal(t, "Fede", got.FirstName)
+	assert.Equal(t, "Laguardia", got.LastName)
+}
+
+func TestRequestBuyerToBuyer_FieldsNil(t *testing.T) {
+	req := models.RequestBuyer{
+		CardNumberId: nil,
+		FirstName:    nil,
+		LastName:     nil,
+	}
+	got := mappers.RequestBuyerToBuyer(req)
+	assert.Equal(t, "", got.CardNumberId)
+	assert.Equal(t, "", got.FirstName)
+	assert.Equal(t, "", got.LastName)
+}
+
+func TestApplyBuyerPatch(t *testing.T) {
+	original := &models.Buyer{Id: 2, CardNumberId: "ORIG", FirstName: "OLD", LastName: "SURNAME"}
+	patch := models.RequestBuyer{CardNumberId: strPtr("PATCHED-ID")}
+	mappers.ApplyBuyerPatch(original, &patch)
+	assert.Equal(t, "PATCHED-ID", original.CardNumberId)
+	assert.Equal(t, "OLD", original.FirstName)
+	assert.Equal(t, "SURNAME", original.LastName)
+
+	patch2 := models.RequestBuyer{FirstName: strPtr("NEWNAME")}
+	mappers.ApplyBuyerPatch(original, &patch2)
+	assert.Equal(t, "NEWNAME", original.FirstName)
+
+	patch3 := models.RequestBuyer{LastName: strPtr("NEWLAST")}
+	mappers.ApplyBuyerPatch(original, &patch3)
+	assert.Equal(t, "NEWLAST", original.LastName)
+
+	patchNone := models.RequestBuyer{}
+	mappers.ApplyBuyerPatch(original, &patchNone)
+	assert.Equal(t, "PATCHED-ID", original.CardNumberId)
+	assert.Equal(t, "NEWNAME", original.FirstName)
+	assert.Equal(t, "NEWLAST", original.LastName)
+}
+
+func TestToResponseBuyer(t *testing.T) {
+	b := &models.Buyer{
+		Id:           7,
+		CardNumberId: "FOO",
+		FirstName:    "X",
+		LastName:     "Y",
+	}
+	r := mappers.ToResponseBuyer(b)
+	expected := models.ResponseBuyer{
+		Id:           7,
+		CardNumberId: "FOO",
+		FirstName:    "X",
+		LastName:     "Y",
+	}
+	assert.Equal(t, expected, r)
+}
+
+func TestToResponseBuyerList(t *testing.T) {
+	buyers := []models.Buyer{
+		{Id: 1, CardNumberId: "A1", FirstName: "A", LastName: "L"},
+		{Id: 2, CardNumberId: "B2", FirstName: "B", LastName: "M"},
+	}
+	got := mappers.ToResponseBuyerList(buyers)
+	expected := []models.ResponseBuyer{
+		{Id: 1, CardNumberId: "A1", FirstName: "A", LastName: "L"},
+		{Id: 2, CardNumberId: "B2", FirstName: "B", LastName: "M"},
+	}
+	assert.Equal(t, expected, got)
+}

--- a/internal/mappers/purchase_order_test.go
+++ b/internal/mappers/purchase_order_test.go
@@ -1,0 +1,82 @@
+package mappers_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/varobledo_meli/W17-G10-Bootcamp.git/internal/mappers"
+	models "github.com/varobledo_meli/W17-G10-Bootcamp.git/pkg/models/buyer"
+)
+
+func TestRequestPurchaseOrderToPurchaseOrder_OK(t *testing.T) {
+	req := models.RequestPurchaseOrder{
+		OrderNumber:     "ORD-42",
+		OrderDate:       "2023-07-15",
+		TrackingCode:    "TRK-123",
+		BuyerID:         1,
+		ProductRecordID: 2,
+	}
+	po, err := mappers.RequestPurchaseOrderToPurchaseOrder(req)
+	assert.NoError(t, err)
+	assert.Equal(t, "ORD-42", po.OrderNumber)
+	assert.True(t, po.OrderDate.Equal(time.Date(2023, 7, 15, 0, 0, 0, 0, time.UTC)), "time parse ok")
+	assert.Equal(t, "TRK-123", po.TrackingCode)
+	assert.Equal(t, 1, po.BuyerID)
+	assert.Equal(t, 2, po.ProductRecordID)
+}
+
+func TestRequestPurchaseOrderToPurchaseOrder_ParseError(t *testing.T) {
+	req := models.RequestPurchaseOrder{
+		OrderNumber:     "ORD-42",
+		OrderDate:       "not-a-date",
+		TrackingCode:    "TRK-123",
+		BuyerID:         1,
+		ProductRecordID: 2,
+	}
+	po, err := mappers.RequestPurchaseOrderToPurchaseOrder(req)
+	assert.Error(t, err)
+	assert.Equal(t, models.PurchaseOrder{}, po)
+}
+
+func TestPurchaseOrderToResponse(t *testing.T) {
+	orderDate := time.Date(2022, 11, 25, 0, 0, 0, 0, time.UTC)
+	po := models.PurchaseOrder{
+		ID:              99,
+		OrderNumber:     "ONO",
+		OrderDate:       orderDate,
+		TrackingCode:    "TRK",
+		BuyerID:         8,
+		ProductRecordID: 20,
+	}
+	resp := mappers.PurchaseOrderToResponse(po)
+	assert.Equal(t, 99, resp.ID)
+	assert.Equal(t, "ONO", resp.OrderNumber)
+	assert.Equal(t, "2022-11-25", resp.OrderDate)
+	assert.Equal(t, "TRK", resp.TrackingCode)
+	assert.Equal(t, 8, resp.BuyerID)
+	assert.Equal(t, 20, resp.ProductRecordID)
+}
+
+func TestToResponsePurchaseOrderList(t *testing.T) {
+	orders := []models.PurchaseOrder{
+		{
+			ID: 1, OrderNumber: "ORD1", OrderDate: time.Date(2021, 3, 4, 0, 0, 0, 0, time.UTC),
+			TrackingCode: "T1", BuyerID: 10, ProductRecordID: 99,
+		},
+		{
+			ID: 2, OrderNumber: "ORD2", OrderDate: time.Date(2022, 4, 5, 0, 0, 0, 0, time.UTC),
+			TrackingCode: "T2", BuyerID: 20, ProductRecordID: 100,
+		},
+	}
+	resp := mappers.ToResponsePurchaseOrderList(orders)
+	assert.Len(t, resp, 2)
+	assert.Equal(t, "ORD1", resp[0].OrderNumber)
+	assert.Equal(t, "2021-03-04", resp[0].OrderDate)
+	assert.Equal(t, 10, resp[0].BuyerID)
+	assert.Equal(t, 99, resp[0].ProductRecordID)
+	assert.Equal(t, "ORD2", resp[1].OrderNumber)
+	assert.Equal(t, "2022-04-05", resp[1].OrderDate)
+	assert.Equal(t, 20, resp[1].BuyerID)
+	assert.Equal(t, 100, resp[1].ProductRecordID)
+}

--- a/internal/validators/buyer_test.go
+++ b/internal/validators/buyer_test.go
@@ -1,0 +1,104 @@
+package validators_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/varobledo_meli/W17-G10-Bootcamp.git/internal/validators"
+	"github.com/varobledo_meli/W17-G10-Bootcamp.git/pkg/api/apperrors"
+	models "github.com/varobledo_meli/W17-G10-Bootcamp.git/pkg/models/buyer"
+)
+
+// helpers para punteros
+func strptr(s string) *string { return &s }
+
+func TestValidateRequestBuyer_AllValid(t *testing.T) {
+	r := models.RequestBuyer{
+		CardNumberId: strptr("123"),
+		FirstName:    strptr("Juan"),
+		LastName:     strptr("Perez"),
+	}
+	err := validators.ValidateRequestBuyer(r)
+	assert.Nil(t, err)
+}
+
+func TestValidateRequestBuyer_MissingFields(t *testing.T) {
+	tests := []struct {
+		name string
+		req  models.RequestBuyer
+	}{
+		{"NilCardNumberId", models.RequestBuyer{CardNumberId: nil, FirstName: strptr("a"), LastName: strptr("b")}},
+		{"NilFirstName", models.RequestBuyer{CardNumberId: strptr("1"), FirstName: nil, LastName: strptr("b")}},
+		{"NilLastName", models.RequestBuyer{CardNumberId: strptr("1"), FirstName: strptr("a"), LastName: nil}},
+		{"EmptyCardNumberId", models.RequestBuyer{CardNumberId: strptr(""), FirstName: strptr("a"), LastName: strptr("b")}},
+		{"EmptyFirstName", models.RequestBuyer{CardNumberId: strptr("1"), FirstName: strptr(""), LastName: strptr("b")}},
+		{"EmptyLastName", models.RequestBuyer{CardNumberId: strptr("1"), FirstName: strptr("a"), LastName: strptr("")}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validators.ValidateRequestBuyer(tc.req)
+			assert.NotNil(t, err)
+			assert.Equal(t, apperrors.CodeValidationError, err.Code)
+		})
+	}
+}
+
+func TestValidateUpdateBuyer_Valid(t *testing.T) {
+	r := models.RequestBuyer{
+		CardNumberId: strptr("123"),
+		FirstName:    strptr("Juan"),
+		LastName:     strptr("Perez"),
+	}
+	err := validators.ValidateUpdateBuyer(r)
+	assert.Nil(t, err)
+}
+
+func TestValidateUpdateBuyer_EmptyFields(t *testing.T) {
+	type tc struct {
+		name     string
+		r        models.RequestBuyer
+		expected string
+	}
+	tests := []tc{
+		{"EmptyCardNumberId", models.RequestBuyer{CardNumberId: strptr("")}, "id_card_number cannot be empty"},
+		{"EmptyFirstName", models.RequestBuyer{FirstName: strptr("")}, "first_name cannot be empty"},
+		{"EmptyLastName", models.RequestBuyer{LastName: strptr("")}, "last_name cannot be empty"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validators.ValidateUpdateBuyer(tt.r)
+			assert.NotNil(t, err)
+			assert.Equal(t, apperrors.CodeValidationError, err.Code)
+			assert.Equal(t, tt.expected, err.Message)
+		})
+	}
+}
+
+func TestValidateUpdateBuyer_AllNil(t *testing.T) {
+	r := models.RequestBuyer{}
+	err := validators.ValidateUpdateBuyer(r)
+	assert.Nil(t, err)
+}
+
+func TestValidateBuyerPatchNotEmpty_AllNil(t *testing.T) {
+	r := models.RequestBuyer{}
+	err := validators.ValidateBuyerPatchNotEmpty(r)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Message, "At least one field is required")
+}
+
+func TestValidateBuyerPatchNotEmpty_AtLeastOnePresent(t *testing.T) {
+	tests := []models.RequestBuyer{
+		{CardNumberId: strptr("1")},
+		{FirstName: strptr("a")},
+		{LastName: strptr("b")},
+		{CardNumberId: strptr("1"), FirstName: strptr("a")},
+	}
+	for i, r := range tests {
+		t.Run("CaseOk#"+string(rune(i+'0')), func(t *testing.T) {
+			err := validators.ValidateBuyerPatchNotEmpty(r)
+			assert.Nil(t, err)
+		})
+	}
+}

--- a/internal/validators/purchase_order_test.go
+++ b/internal/validators/purchase_order_test.go
@@ -1,0 +1,100 @@
+package validators_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/varobledo_meli/W17-G10-Bootcamp.git/internal/validators"
+	"github.com/varobledo_meli/W17-G10-Bootcamp.git/pkg/api/apperrors"
+	models "github.com/varobledo_meli/W17-G10-Bootcamp.git/pkg/models/buyer"
+)
+
+func validPurchaseOrder() models.RequestPurchaseOrder {
+	return models.RequestPurchaseOrder{
+		OrderNumber:     "ORDER123",
+		OrderDate:       time.Now().Format(time.RFC3339),
+		TrackingCode:    "TRACK123",
+		BuyerID:         10,
+		ProductRecordID: 20,
+	}
+}
+
+func TestValidatePurchaseOrderPost_Valid(t *testing.T) {
+	po := validPurchaseOrder()
+	err := validators.ValidatePurchaseOrderPost(po)
+	assert.Nil(t, err)
+}
+
+func TestValidatePurchaseOrderPost_MissingOrderNumber(t *testing.T) {
+	po := validPurchaseOrder()
+	po.OrderNumber = ""
+	err := validators.ValidatePurchaseOrderPost(po)
+	assert.NotNil(t, err)
+	appErr, ok := err.(*apperrors.AppError)
+	assert.True(t, ok)
+	assert.Equal(t, apperrors.CodeValidationError, appErr.Code)
+	assert.Equal(t, "order_number is required", appErr.Message)
+}
+
+func TestValidatePurchaseOrderPost_MissingOrderDate(t *testing.T) {
+	po := validPurchaseOrder()
+	po.OrderDate = ""
+	err := validators.ValidatePurchaseOrderPost(po)
+	assert.NotNil(t, err)
+	appErr, ok := err.(*apperrors.AppError)
+	assert.True(t, ok)
+	assert.Equal(t, apperrors.CodeValidationError, appErr.Code)
+	assert.Equal(t, "order_date is required", appErr.Message)
+}
+
+func TestValidatePurchaseOrderPost_InvalidOrderDateFormat(t *testing.T) {
+	po := validPurchaseOrder()
+	po.OrderDate = "not-a-date"
+	err := validators.ValidatePurchaseOrderPost(po)
+	assert.NotNil(t, err)
+	appErr, ok := err.(*apperrors.AppError)
+	assert.True(t, ok)
+	assert.Equal(t, apperrors.CodeBadRequest, appErr.Code)
+	assert.Equal(t, "Invalid request body", appErr.Message)
+}
+
+func TestValidatePurchaseOrderPost_MissingTrackingCode(t *testing.T) {
+	po := validPurchaseOrder()
+	po.TrackingCode = ""
+	err := validators.ValidatePurchaseOrderPost(po)
+	assert.NotNil(t, err)
+	appErr, ok := err.(*apperrors.AppError)
+	assert.True(t, ok)
+	assert.Equal(t, apperrors.CodeValidationError, appErr.Code)
+	assert.Equal(t, "tracking_code is required", appErr.Message)
+}
+
+func TestValidatePurchaseOrderPost_BuyerIDZeroOrNegative(t *testing.T) {
+	cases := []int{0, -1}
+	for _, v := range cases {
+		po := validPurchaseOrder()
+		po.BuyerID = v
+		err := validators.ValidatePurchaseOrderPost(po)
+		assert.NotNil(t, err)
+		appErr, ok := err.(*apperrors.AppError)
+		assert.True(t, ok)
+		assert.Equal(t, apperrors.CodeValidationError, appErr.Code)
+		assert.Equal(t, "buyer_id must be greater than 0", appErr.Message)
+	}
+}
+
+func TestValidatePurchaseOrderPost_ProductRecordIDZeroOrNegative(t *testing.T) {
+	cases := []int64{0, -5}
+	for _, v := range cases {
+		po := validPurchaseOrder()
+		po.ProductRecordID = int(v)
+		err := validators.ValidatePurchaseOrderPost(po)
+		assert.NotNil(t, err)
+		appErr, ok := err.(*apperrors.AppError)
+		assert.True(t, ok)
+		assert.Equal(t, apperrors.CodeValidationError, appErr.Code)
+		assert.Equal(t, "product_record_id must be greater than 0", appErr.Message)
+	}
+}


### PR DESCRIPTION
This pull request increases unit test coverage for the buyer purchase order mapping logic in the mappers package. 
The following improvements have been made, comprehensive tests for the:
-  RequestPurchaseOrderToPurchaseOrder
- PurchaseOrderToResponse
- ToResponsePurchaseOrderList 
-  RequestBuyerToBuyer
- ApplyBuyerPatch
- ToResponseBuyer
- ToResponseBuyerLis
This functions using table-driven scenarios and covering both success and error cases; correction of test assertions to match the actual model types, utilize stretchr/testify for assertions. 