### PR TITLE
test: add unit tests for pkg/api request, httputil, response, and JSON error handling

### DIFF
--- a/internal/validators/product_batches_test.go
+++ b/internal/validators/product_batches_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 )
 
-func intPtr(v int) *int             { return &v }
 func float64Ptr(v float64) *float64 { return &v }
 
 func validPostProductBatch() models.PostProductBatches {

--- a/pkg/api/apperrors/errors_test.go
+++ b/pkg/api/apperrors/errors_test.go
@@ -1,0 +1,72 @@
+package apperrors_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/varobledo_meli/W17-G10-Bootcamp.git/pkg/api/apperrors"
+)
+
+func TestNewAppError_KnownAndUnknownCode(t *testing.T) {
+	// Debe encontrar el status del code conocido
+	appErr := apperrors.NewAppError(apperrors.CodeInternal, "err")
+	require.Equal(t, apperrors.CodeInternal, appErr.Code)
+	require.Equal(t, "err", appErr.Message)
+	require.Greater(t, appErr.HTTPStatus, 0)
+	require.Empty(t, appErr.Details)
+
+	// Code desconocido: debe quedarse con status 500
+	unknown := apperrors.NewAppError("FAKE_CODE_X", "nope")
+	require.Equal(t, 500, unknown.HTTPStatus)
+	require.Equal(t, "FAKE_CODE_X", unknown.Code)
+	require.Equal(t, "nope", unknown.Message)
+}
+
+func TestAppError_ErrorMethod(t *testing.T) {
+	appErr := apperrors.NewAppError(apperrors.CodeInternal, "msg here")
+	require.Contains(t, appErr.Error(), appErr.Code)
+	require.Contains(t, appErr.Error(), "msg here")
+}
+
+func TestAppError_WithDetail_IsImmutable(t *testing.T) {
+	e1 := apperrors.NewAppError("SOME", "test with details")
+	e2 := e1.WithDetail("field", "value")
+
+	require.NotSame(t, e1, e2, "should return a new instance")
+	require.Empty(t, e1.Details)
+	require.Equal(t, "value", e2.Details["field"])
+
+	// Con más detalles, viejo debe seguir sin cambios
+	e3 := e2.WithDetail("other", 123)
+	require.NotSame(t, e2, e3)
+	require.Equal(t, "value", e3.Details["field"])
+	require.Equal(t, 123, e3.Details["other"])
+	require.Empty(t, e1.Details)
+}
+
+func TestAppError_Wrap(t *testing.T) {
+	// Nil retorna nil
+	require.Nil(t, apperrors.Wrap(nil, "ignore"))
+
+	// Ya es app error: retorna el mismo
+	orig := apperrors.NewAppError(apperrors.CodeInternal, "msg")
+	result := apperrors.Wrap(orig, "x")
+	require.Equal(t, orig, result)
+
+	// Error de Go: debe devolver AppError nuevo
+	ext := errors.New("foo error")
+	wrapped := apperrors.Wrap(ext, "wrapped!")
+	require.NotNil(t, wrapped)
+	require.Equal(t, apperrors.CodeInternal, wrapped.Code)
+	require.Equal(t, "wrapped!", wrapped.Message)
+}
+
+func TestIsAppError(t *testing.T) {
+	appErr := apperrors.NewAppError("CODE1", "x")
+	normal := errors.New("not app error")
+
+	require.True(t, apperrors.IsAppError(appErr, "CODE1"))
+	require.False(t, apperrors.IsAppError(normal, "CODE1"))
+	require.False(t, apperrors.IsAppError(appErr, "CODE_ERR"))
+}

--- a/pkg/api/httputil/request_test.go
+++ b/pkg/api/httputil/request_test.go
@@ -1,0 +1,126 @@
+package httputil_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/require"
+	"github.com/varobledo_meli/W17-G10-Bootcamp.git/pkg/api/apperrors"
+	httputil "github.com/varobledo_meli/W17-G10-Bootcamp.git/pkg/api/httputil"
+	"github.com/varobledo_meli/W17-G10-Bootcamp.git/pkg/api/response"
+)
+
+func setChiParam(req *http.Request, name, value string) *http.Request {
+	routeCtx := chi.NewRouteContext()
+	routeCtx.URLParams.Add(name, value)
+	return req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, routeCtx))
+}
+
+// Helper para decodificar body de error
+func decodeErrBody(t *testing.T, rec *httptest.ResponseRecorder) response.ErrorResponse {
+	var errResp response.ErrorResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &errResp))
+	return errResp
+}
+
+func TestMethodNotAllowedHandler(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/foo", nil)
+	httputil.MethodNotAllowedHandler(rec, req)
+
+	require.Equal(t, http.StatusMethodNotAllowed, rec.Code)
+	errResp := decodeErrBody(t, rec)
+	require.Equal(t, apperrors.CodeMethodNotAllowed, errResp.Error.Code)
+	require.Contains(t, errResp.Error.Message, "method not allowed")
+}
+
+func TestNotFoundHandler(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/notfound", nil)
+	httputil.NotFoundHandler(rec, req)
+	require.Equal(t, http.StatusNotFound, rec.Code)
+	errResp := decodeErrBody(t, rec)
+	require.Equal(t, apperrors.CodeNotFound, errResp.Error.Code)
+	require.Contains(t, errResp.Error.Message, "endpoint not found")
+}
+
+func TestDecodeJSON(t *testing.T) {
+	type myJSON struct {
+		Name string `json:"name"`
+		Num  int    `json:"num"`
+	}
+	t.Run("fail if body is nil", func(t *testing.T) {
+		req := httptest.NewRequest("POST", "/", nil)
+		req.Body = nil
+		var dest myJSON
+		err := httputil.DecodeJSON(req, &dest)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "request body is required")
+	})
+	t.Run("fail on invalid JSON", func(t *testing.T) {
+		bad := strings.NewReader("not json!")
+		req := httptest.NewRequest("POST", "/", bad)
+		var dest myJSON
+		err := httputil.DecodeJSON(req, &dest)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid JSON format")
+	})
+	t.Run("successfully decodes good JSON", func(t *testing.T) {
+		data := map[string]any{"name": "ok", "num": 42}
+		buf, _ := json.Marshal(data)
+		req := httptest.NewRequest("POST", "/", bytes.NewReader(buf))
+		var dest myJSON
+		err := httputil.DecodeJSON(req, &dest)
+		require.NoError(t, err)
+		require.Equal(t, "ok", dest.Name)
+		require.Equal(t, 42, dest.Num)
+	})
+}
+
+func TestParseIDParam(t *testing.T) {
+	t.Run("returns error if param is missing", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/foo", nil)
+		id, err := httputil.ParseIDParam(req, "id")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "id parameter is required")
+		require.Equal(t, 0, id)
+	})
+
+	t.Run("returns error if param is not an int", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/foo/abc", nil)
+		req = setChiParam(req, "id", "abc")
+		id, err := httputil.ParseIDParam(req, "id")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "must be a valid integer")
+		require.Equal(t, 0, id)
+	})
+
+	t.Run("returns error if param is zero or negative", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/foo/0", nil)
+		req = setChiParam(req, "id", "0")
+		id, err := httputil.ParseIDParam(req, "id")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "must be a positive integer")
+		require.Equal(t, 0, id)
+
+		req = setChiParam(req, "id", "-5")
+		id, err = httputil.ParseIDParam(req, "id")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "must be a positive integer")
+		require.Equal(t, 0, id)
+	})
+
+	t.Run("success with positive int param", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/foo/13", nil)
+		req = setChiParam(req, "id", "13")
+		id, err := httputil.ParseIDParam(req, "id")
+		require.NoError(t, err)
+		require.Equal(t, 13, id)
+	})
+}

--- a/pkg/api/request/json_test.go
+++ b/pkg/api/request/json_test.go
@@ -1,0 +1,64 @@
+package request_test
+
+import (
+	"github.com/stretchr/testify/require"
+	"github.com/varobledo_meli/W17-G10-Bootcamp.git/pkg/api/request"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+type dummyStruct struct {
+	Name  string `json:"name"`
+	Count int    `json:"count"`
+}
+
+func TestJSON(t *testing.T) {
+	tests := []struct {
+		name        string
+		contentType string
+		body        string
+		expectErr   error
+		wantVal     *dummyStruct
+	}{
+		{
+			name:        "fails if not application/json",
+			contentType: "text/plain",
+			body:        `{"name":"Go","count":42}`,
+			expectErr:   request.ErrRequestContentTypeNotJSON,
+			wantVal:     nil,
+		},
+		{
+			name:        "fails if bad JSON",
+			contentType: "application/json",
+			body:        `not valid json!`,
+			expectErr:   request.ErrRequestJSONInvalid,
+			wantVal:     nil,
+		},
+		{
+			name:        "decodes valid JSON",
+			contentType: "application/json",
+			body:        `{"name":"Team","count":99}`,
+			expectErr:   nil,
+			wantVal:     &dummyStruct{Name: "Team", Count: 99},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/endpoint", strings.NewReader(tc.body))
+			req.Header.Set("Content-Type", tc.contentType)
+
+			var got dummyStruct
+			err := request.JSON(req, &got)
+			if tc.expectErr != nil {
+				require.Error(t, err)
+				require.ErrorIs(t, err, tc.expectErr)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.wantVal, &got)
+			}
+		})
+	}
+}

--- a/pkg/api/response/error_test.go
+++ b/pkg/api/response/error_test.go
@@ -25,7 +25,7 @@ func TestError(t *testing.T) {
 		wantAppCode string
 		wantMsgSub  string
 		wantDetails map[string]interface{}
-		wantRaw     string // Solo para casos de encoder fallback (si lo quieres explorar)
+		wantRaw     string
 	}{
 		{
 			name:        "nil error gives internal server error",

--- a/pkg/api/response/error_test.go
+++ b/pkg/api/response/error_test.go
@@ -1,0 +1,84 @@
+package response_test
+
+import (
+	"encoding/json"
+	"errors"
+	"github.com/stretchr/testify/require"
+	"github.com/varobledo_meli/W17-G10-Bootcamp.git/pkg/api/apperrors"
+	"github.com/varobledo_meli/W17-G10-Bootcamp.git/pkg/api/response"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func decodeErrorBody(t *testing.T, rec *httptest.ResponseRecorder) response.ErrorResponse {
+	var errResp response.ErrorResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &errResp))
+	return errResp
+}
+
+func TestError(t *testing.T) {
+	tests := []struct {
+		name        string
+		inputErr    error
+		wantCode    int
+		wantAppCode string
+		wantMsgSub  string
+		wantDetails map[string]interface{}
+		wantRaw     string // Solo para casos de encoder fallback (si lo quieres explorar)
+	}{
+		{
+			name:        "nil error gives internal server error",
+			inputErr:    nil,
+			wantCode:    http.StatusInternalServerError,
+			wantAppCode: apperrors.CodeInternal,
+			wantMsgSub:  "Unexpected nil error",
+		},
+		{
+			name:        "typed AppError sets code, message, status",
+			inputErr:    apperrors.NewAppError(apperrors.CodeBadRequest, "bad request"),
+			wantCode:    http.StatusBadRequest,
+			wantAppCode: apperrors.CodeBadRequest,
+			wantMsgSub:  "bad request",
+		},
+		{
+			name: "typed AppError with details sets details",
+			inputErr: func() error {
+				e := apperrors.NewAppError(apperrors.CodeValidationError, "validation error")
+				e.Details = map[string]interface{}{"field": "name", "msg": "required"}
+				return e
+			}(),
+			wantCode:    http.StatusUnprocessableEntity,
+			wantAppCode: apperrors.CodeValidationError,
+			wantMsgSub:  "validation error",
+			wantDetails: map[string]interface{}{"field": "name", "msg": "required"},
+		},
+		{
+			name:        "normal error gives 500",
+			inputErr:    errors.New("some string error"),
+			wantCode:    http.StatusInternalServerError,
+			wantAppCode: apperrors.CodeInternal,
+			wantMsgSub:  "internal server error",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			response.Error(rec, tc.inputErr)
+
+			require.Equal(t, tc.wantCode, rec.Code)
+			if tc.wantRaw != "" {
+				require.Contains(t, rec.Body.String(), tc.wantRaw)
+				return
+			}
+			errResp := decodeErrorBody(t, rec)
+
+			require.Equal(t, tc.wantAppCode, errResp.Error.Code)
+			require.Contains(t, errResp.Error.Message, tc.wantMsgSub)
+			if len(tc.wantDetails) > 0 {
+				require.Equal(t, tc.wantDetails, errResp.Error.Details)
+			}
+		})
+	}
+}

--- a/pkg/api/response/json_test.go
+++ b/pkg/api/response/json_test.go
@@ -16,7 +16,7 @@ func TestJSON(t *testing.T) {
 		input         any
 		wantStatus    int
 		wantData      any
-		skipTypeCheck bool // para tipo no comparable, ej: map
+		skipTypeCheck bool
 	}{
 		{
 			name:       "returns json with data object",
@@ -30,7 +30,7 @@ func TestJSON(t *testing.T) {
 			code:       http.StatusCreated,
 			input:      []string{"a", "b", "c"},
 			wantStatus: http.StatusCreated,
-			wantData:   []any{"a", "b", "c"}, // por tipo JSON decode es []any, no []string
+			wantData:   []any{"a", "b", "c"},
 		},
 		{
 			name:       "returns only status if body is nil",
@@ -48,21 +48,18 @@ func TestJSON(t *testing.T) {
 			require.Equal(t, tc.wantStatus, rec.Code)
 
 			if tc.input == nil {
-				// No JSON, no Content-Type
 				require.Empty(t, rec.Body.String())
 				return
 			}
 
 			require.Equal(t, "application/json", rec.Header().Get("Content-Type"))
 
-			// Desempaqueta envelope y compara Data
 			var resp struct {
 				Data any `json:"data"`
 			}
 			err := json.Unmarshal(rec.Body.Bytes(), &resp)
 			require.NoError(t, err)
 
-			// Si es slice/map, compara con ElementsMatch o omite tipo
 			if m, ok := tc.wantData.([]any); ok {
 				require.ElementsMatch(t, m, resp.Data.([]any))
 			} else if mp, ok := tc.wantData.(map[string]any); ok {

--- a/pkg/api/response/json_test.go
+++ b/pkg/api/response/json_test.go
@@ -1,0 +1,75 @@
+package response_test
+
+import (
+	"encoding/json"
+	"github.com/stretchr/testify/require"
+	"github.com/varobledo_meli/W17-G10-Bootcamp.git/pkg/api/response"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestJSON(t *testing.T) {
+	tests := []struct {
+		name          string
+		code          int
+		input         any
+		wantStatus    int
+		wantData      any
+		skipTypeCheck bool // para tipo no comparable, ej: map
+	}{
+		{
+			name:       "returns json with data object",
+			code:       http.StatusOK,
+			input:      map[string]any{"foo": "bar"},
+			wantStatus: http.StatusOK,
+			wantData:   map[string]any{"foo": "bar"},
+		},
+		{
+			name:       "response with slice",
+			code:       http.StatusCreated,
+			input:      []string{"a", "b", "c"},
+			wantStatus: http.StatusCreated,
+			wantData:   []any{"a", "b", "c"}, // por tipo JSON decode es []any, no []string
+		},
+		{
+			name:       "returns only status if body is nil",
+			code:       http.StatusAccepted,
+			input:      nil,
+			wantStatus: http.StatusAccepted,
+			wantData:   nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			response.JSON(rec, tc.code, tc.input)
+			require.Equal(t, tc.wantStatus, rec.Code)
+
+			if tc.input == nil {
+				// No JSON, no Content-Type
+				require.Empty(t, rec.Body.String())
+				return
+			}
+
+			require.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+
+			// Desempaqueta envelope y compara Data
+			var resp struct {
+				Data any `json:"data"`
+			}
+			err := json.Unmarshal(rec.Body.Bytes(), &resp)
+			require.NoError(t, err)
+
+			// Si es slice/map, compara con ElementsMatch o omite tipo
+			if m, ok := tc.wantData.([]any); ok {
+				require.ElementsMatch(t, m, resp.Data.([]any))
+			} else if mp, ok := tc.wantData.(map[string]any); ok {
+				require.Equal(t, mp, resp.Data)
+			} else {
+				require.Equal(t, tc.wantData, resp.Data)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds comprehensive unit tests for the core API utility packages:

- pkg/api/request: covers input decoding and request validation.
- pkg/api/response: covers JSON serialization, error envelope, and content-type handling.
- pkg/api/httputil: covers parameter parsing, path/query utilities, and error handling for HTTP endpoints.
- pkg/api/json errors: ensures proper detection and propagation of JSON decoding errors and response formatting.
