### PR TITLE
feat: add loggs to carry handler, service and repository

### DIFF
--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -127,6 +127,9 @@ func (s *ServerChi) Run(mysql *sql.DB) (err error) {
 	repoWarehouse.SetLogger(appLogger)
 	svcWarehouse.SetLogger(appLogger)
 
+	repoCarry.SetLogger(appLogger)
+	svcCarry.SetLogger(appLogger)
+
 	appLogger.Info(ctx, "server", "All services initialized successfully")
 
 	// - handler
@@ -145,6 +148,7 @@ func (s *ServerChi) Run(mysql *sql.DB) (err error) {
 
 	// Inject logger into warehouse handler
 	hdWarehouse.SetLogger(appLogger)
+	hdCarry.SetLogger(appLogger)
 
 	appLogger.Info(ctx, "server", "All handlers initialized successfully")
 

--- a/internal/handler/carry/carry.go
+++ b/internal/handler/carry/carry.go
@@ -4,10 +4,11 @@ import (
 	"net/http"
 
 	"github.com/varobledo_meli/W17-G10-Bootcamp.git/internal/mappers"
-	"github.com/varobledo_meli/W17-G10-Bootcamp.git/internal/service/carry"
+	service "github.com/varobledo_meli/W17-G10-Bootcamp.git/internal/service/carry"
 	"github.com/varobledo_meli/W17-G10-Bootcamp.git/internal/validators"
 	"github.com/varobledo_meli/W17-G10-Bootcamp.git/pkg/api/request"
 	"github.com/varobledo_meli/W17-G10-Bootcamp.git/pkg/api/response"
+	"github.com/varobledo_meli/W17-G10-Bootcamp.git/pkg/logger"
 	"github.com/varobledo_meli/W17-G10-Bootcamp.git/pkg/models/carry"
 )
 
@@ -17,18 +18,36 @@ func NewCarryHandler(sv service.CarryService) *CarryHandler {
 
 type CarryHandler struct {
 	// sv is the service that will be used by the handler
-	sv service.CarryService
+	sv     service.CarryService
+	logger logger.Logger
+}
+
+// SetLogger allows injecting the logger after creation
+func (h *CarryHandler) SetLogger(l logger.Logger) {
+	h.logger = l
 }
 
 func (h *CarryHandler) Create(w http.ResponseWriter, r *http.Request) {
+	h.logger.Info(r.Context(), "carry", "Starting carry creation request")
+
 	var req = carry.CarryRequest{}
 	if err := request.JSON(r, &req); err != nil {
-		response.Error(w, err)
+		h.logger.Error(r.Context(), "carry", "Failed to parse JSON request", err)
+		response.ErrorWithRequest(w, r, err)
 		return
 	}
 
+	h.logger.Debug(r.Context(), "carry", "Carry request parsed successfully", map[string]interface{}{
+		"company_name": req.CompanyName,
+		"cid":          req.Cid,
+	})
+
 	if err := validators.ValidateCarryCreateRequest(req); err != nil {
-		response.Error(w, err)
+		h.logger.Warning(r.Context(), "carry", "Carry validation failed", map[string]interface{}{
+			"error":        err.Error(),
+			"company_name": req.CompanyName,
+		})
+		response.ErrorWithRequest(w, r, err)
 		return
 	}
 
@@ -36,25 +55,45 @@ func (h *CarryHandler) Create(w http.ResponseWriter, r *http.Request) {
 
 	newC, err := h.sv.Create(r.Context(), wh)
 	if err != nil {
-		response.Error(w, err)
+		h.logger.Error(r.Context(), "carry", "Failed to create carry", err, map[string]interface{}{
+			"company_name": req.CompanyName,
+			"cid":          req.Cid,
+		})
+		response.ErrorWithRequest(w, r, err)
 		return
 	}
 
+	h.logger.Info(r.Context(), "carry", "Carry created successfully", map[string]interface{}{
+		"carry_id":     newC.Id,
+		"company_name": newC.CompanyName,
+		"cid":          newC.Cid,
+	})
 	response.JSON(w, http.StatusCreated, mappers.CarryToDoc(newC))
 }
 
 func (h *CarryHandler) ReportCarries(w http.ResponseWriter, r *http.Request) {
+	h.logger.Info(r.Context(), "carry", "Starting carries report request")
+
 	idParam := r.URL.Query().Get("id")
 	var localityID *string = nil
 	if idParam != "" {
 		localityID = &idParam
+		h.logger.Debug(r.Context(), "carry", "Filtering carries report by locality", map[string]interface{}{
+			"locality_id": idParam,
+		})
 	}
 
 	result, err := h.sv.GetCarriesReport(r.Context(), localityID)
 	if err != nil {
-		response.Error(w, err)
+		h.logger.Error(r.Context(), "carry", "Failed to get carries report", err, map[string]interface{}{
+			"locality_id": idParam,
+		})
+		response.ErrorWithRequest(w, r, err)
 		return
 	}
 
+	h.logger.Info(r.Context(), "carry", "Carries report generated successfully", map[string]interface{}{
+		"locality_id": idParam,
+	})
 	response.JSON(w, http.StatusOK, result)
 }

--- a/internal/handler/carry/carry.go
+++ b/internal/handler/carry/carry.go
@@ -28,22 +28,22 @@ func (h *CarryHandler) SetLogger(l logger.Logger) {
 }
 
 func (h *CarryHandler) Create(w http.ResponseWriter, r *http.Request) {
-	h.logger.Info(r.Context(), "carry", "Starting carry creation request")
+	h.logger.Info(r.Context(), "carry-handler", "Starting carry creation request")
 
 	var req = carry.CarryRequest{}
 	if err := request.JSON(r, &req); err != nil {
-		h.logger.Error(r.Context(), "carry", "Failed to parse JSON request", err)
+		h.logger.Error(r.Context(), "carry-handler", "Failed to parse JSON request", err)
 		response.ErrorWithRequest(w, r, err)
 		return
 	}
 
-	h.logger.Debug(r.Context(), "carry", "Carry request parsed successfully", map[string]interface{}{
+	h.logger.Debug(r.Context(), "carry-handler", "Carry request parsed successfully", map[string]interface{}{
 		"company_name": req.CompanyName,
 		"cid":          req.Cid,
 	})
 
 	if err := validators.ValidateCarryCreateRequest(req); err != nil {
-		h.logger.Warning(r.Context(), "carry", "Carry validation failed", map[string]interface{}{
+		h.logger.Warning(r.Context(), "carry-handler", "Carry validation failed", map[string]interface{}{
 			"error":        err.Error(),
 			"company_name": req.CompanyName,
 		})
@@ -55,7 +55,7 @@ func (h *CarryHandler) Create(w http.ResponseWriter, r *http.Request) {
 
 	newC, err := h.sv.Create(r.Context(), wh)
 	if err != nil {
-		h.logger.Error(r.Context(), "carry", "Failed to create carry", err, map[string]interface{}{
+		h.logger.Error(r.Context(), "carry-handler", "Failed to create carry", err, map[string]interface{}{
 			"company_name": req.CompanyName,
 			"cid":          req.Cid,
 		})
@@ -63,7 +63,7 @@ func (h *CarryHandler) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	h.logger.Info(r.Context(), "carry", "Carry created successfully", map[string]interface{}{
+	h.logger.Info(r.Context(), "carry-handler", "Carry created successfully", map[string]interface{}{
 		"carry_id":     newC.Id,
 		"company_name": newC.CompanyName,
 		"cid":          newC.Cid,
@@ -72,27 +72,27 @@ func (h *CarryHandler) Create(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *CarryHandler) ReportCarries(w http.ResponseWriter, r *http.Request) {
-	h.logger.Info(r.Context(), "carry", "Starting carries report request")
+	h.logger.Info(r.Context(), "carry-handler", "Starting carries report request")
 
 	idParam := r.URL.Query().Get("id")
 	var localityID *string = nil
 	if idParam != "" {
 		localityID = &idParam
-		h.logger.Debug(r.Context(), "carry", "Filtering carries report by locality", map[string]interface{}{
+		h.logger.Debug(r.Context(), "carry-handler", "Filtering carries report by locality", map[string]interface{}{
 			"locality_id": idParam,
 		})
 	}
 
 	result, err := h.sv.GetCarriesReport(r.Context(), localityID)
 	if err != nil {
-		h.logger.Error(r.Context(), "carry", "Failed to get carries report", err, map[string]interface{}{
+		h.logger.Error(r.Context(), "carry-handler", "Failed to get carries report", err, map[string]interface{}{
 			"locality_id": idParam,
 		})
 		response.ErrorWithRequest(w, r, err)
 		return
 	}
 
-	h.logger.Info(r.Context(), "carry", "Carries report generated successfully", map[string]interface{}{
+	h.logger.Info(r.Context(), "carry-handler", "Carries report generated successfully", map[string]interface{}{
 		"locality_id": idParam,
 	})
 	response.JSON(w, http.StatusOK, result)

--- a/internal/repository/carry/carry.go
+++ b/internal/repository/carry/carry.go
@@ -19,23 +19,52 @@ const (
 // Handles specific MySQL errors for duplicate CID and invalid locality_id
 // Returns the created carrier with its generated ID or an error if the operation fails
 func (r *CarryMySQL) Create(ctx context.Context, c carry.Carry) (*carry.Carry, error) {
+	r.logger.Info(ctx, "carry-repository", "Starting carry creation in database", map[string]interface{}{
+		"company_name": c.CompanyName,
+		"cid":          c.Cid,
+		"locality_id":  c.LocalityId,
+	})
+
 	res, err := r.db.ExecContext(ctx, queryCarryCreate, c.Cid, c.CompanyName, c.Address, c.Telephone, c.LocalityId)
 	if err != nil {
 		if mysqlErr, ok := err.(*mysql.MySQLError); ok {
 			switch mysqlErr.Number {
 			case 1062:
+				r.logger.Warning(ctx, "carry-repository", "Carry creation failed - CID already exists", map[string]interface{}{
+					"cid":         c.Cid,
+					"mysql_error": mysqlErr.Number,
+				})
 				return nil, apperrors.NewAppError(apperrors.CodeConflict, "cid already exists")
 			case 1452:
+				r.logger.Warning(ctx, "carry-repository", "Carry creation failed - locality_id does not exist", map[string]interface{}{
+					"locality_id": c.LocalityId,
+					"mysql_error": mysqlErr.Number,
+				})
 				return nil, apperrors.NewAppError(apperrors.CodeConflict, "locality_id does not exist")
 			}
 		}
+		r.logger.Error(ctx, "carry-repository", "Database error during carry creation", err, map[string]interface{}{
+			"company_name": c.CompanyName,
+			"cid":          c.Cid,
+		})
 		return nil, apperrors.Wrap(err, "error creating carry")
 	}
+
 	id, err := res.LastInsertId()
 	if err != nil {
+		r.logger.Error(ctx, "carry-repository", "Failed to get last insert ID", err, map[string]interface{}{
+			"company_name": c.CompanyName,
+			"cid":          c.Cid,
+		})
 		return nil, apperrors.Wrap(err, "error creating carry")
 	}
+
 	c.Id = int(id)
+	r.logger.Info(ctx, "carry-repository", "Carry created successfully in database", map[string]interface{}{
+		"carry_id":     c.Id,
+		"company_name": c.CompanyName,
+		"cid":          c.Cid,
+	})
 	return &c, nil
 }
 
@@ -43,8 +72,11 @@ func (r *CarryMySQL) Create(ctx context.Context, c carry.Carry) (*carry.Carry, e
 // Joins carriers with localities table to get locality names along with counts
 // Returns a slice of CarriesReport containing locality information and carrier counts
 func (r *CarryMySQL) GetCarriesCountByAllLocalities(ctx context.Context) ([]carry.CarriesReport, error) {
+	r.logger.Info(ctx, "carry-repository", "Starting query for carries count by all localities")
+
 	rows, err := r.db.QueryContext(ctx, queryCarriesCountByAllLocalities)
 	if err != nil {
+		r.logger.Error(ctx, "carry-repository", "Database query failed for carries count by all localities", err)
 		return nil, err
 	}
 	defer rows.Close()
@@ -53,14 +85,22 @@ func (r *CarryMySQL) GetCarriesCountByAllLocalities(ctx context.Context) ([]carr
 	for rows.Next() {
 		var cc carry.CarriesReport
 		if err := rows.Scan(&cc.LocalityID, &cc.LocalityName, &cc.CarriesCount); err != nil {
+			r.logger.Warning(ctx, "carry-repository", "Failed to scan row in carries count query", map[string]interface{}{
+				"error": err.Error(),
+			})
 			continue
 		}
 		results = append(results, cc)
 	}
 
 	if err := rows.Err(); err != nil {
+		r.logger.Error(ctx, "carry-repository", "Row iteration error in carries count query", err)
 		return nil, apperrors.Wrap(err, "error getting carries count by all localities")
 	}
+
+	r.logger.Info(ctx, "carry-repository", "Successfully retrieved carries count by all localities", map[string]interface{}{
+		"results_count": len(results),
+	})
 	return results, nil
 }
 
@@ -68,10 +108,23 @@ func (r *CarryMySQL) GetCarriesCountByAllLocalities(ctx context.Context) ([]carr
 // Joins carriers with localities table to get locality name along with count
 // Returns a CarriesReport containing locality information and carrier count for the specified locality
 func (r *CarryMySQL) GetCarriesCountByLocalityID(ctx context.Context, localityID string) (*carry.CarriesReport, error) {
+	r.logger.Debug(ctx, "carry-repository", "Starting query for carries count by specific locality", map[string]interface{}{
+		"locality_id": localityID,
+	})
+
 	var cc carry.CarriesReport
 	err := r.db.QueryRowContext(ctx, queryCarriesCountByLocalityID, localityID).Scan(&cc.LocalityID, &cc.LocalityName, &cc.CarriesCount)
 	if err != nil {
+		r.logger.Error(ctx, "carry-repository", "Database query failed for carries count by locality ID", err, map[string]interface{}{
+			"locality_id": localityID,
+		})
 		return nil, apperrors.Wrap(err, "error getting carries count by locality id")
 	}
-	return &cc, err
+
+	r.logger.Info(ctx, "carry-repository", "Successfully retrieved carries count by locality ID", map[string]interface{}{
+		"locality_id":   localityID,
+		"locality_name": cc.LocalityName,
+		"carries_count": cc.CarriesCount,
+	})
+	return &cc, nil
 }

--- a/internal/repository/carry/carry_interface.go
+++ b/internal/repository/carry/carry_interface.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 
+	"github.com/varobledo_meli/W17-G10-Bootcamp.git/pkg/logger"
 	"github.com/varobledo_meli/W17-G10-Bootcamp.git/pkg/models/carry"
 )
 
@@ -15,8 +16,14 @@ type CarryRepository interface {
 
 type CarryMySQL struct {
 	db *sql.DB
+	logger logger.Logger
 }
 
 func NewCarryRepository(db *sql.DB) *CarryMySQL {
-	return &CarryMySQL{db}
+	return &CarryMySQL{db : db}
+}
+
+// SetLogger allows you to inject the logger after creation
+func (r *CarryMySQL) SetLogger(l logger.Logger) {
+	r.logger = l
 }

--- a/internal/service/carry/carry.go
+++ b/internal/service/carry/carry.go
@@ -10,7 +10,12 @@ import (
 // Create creates a new carrier by delegating to the repository layer
 // Returns the created carrier or an error if the operation fails
 func (s *CarryDefault) Create(ctx context.Context, c carry.Carry) (*carry.Carry, error) {
-	return s.rp.Create(ctx, c)
+	result, err := s.rp.Create(ctx, c)
+	if err != nil {
+		return nil, err
+	}
+	
+	return result, nil
 }
 
 // GetCarriesReport retrieves carrier statistics based on locality filtering
@@ -18,13 +23,58 @@ func (s *CarryDefault) Create(ctx context.Context, c carry.Carry) (*carry.Carry,
 // If localityID is provided, returns statistics for that specific locality
 // Returns either a slice of CarriesReport (all localities) or a single CarriesReport (specific locality)
 func (s *CarryDefault) GetCarriesReport(ctx context.Context, localityID *string) (interface{}, error) {
+	s.logger.Info(ctx, "carry-service", "Starting carries report generation", map[string]interface{}{
+		"locality_id": localityID,
+	})
+
 	if localityID == nil {
-		return s.rp.GetCarriesCountByAllLocalities(ctx)
+		s.logger.Debug(ctx, "carry-service", "Generating report for all localities")
+
+		result, err := s.rp.GetCarriesCountByAllLocalities(ctx)
+		if err != nil {
+			s.logger.Error(ctx, "carry-service", "Failed to get carries count for all localities", err)
+			return nil, err
+		}
+
+		s.logger.Info(ctx, "carry-service", "Successfully generated report for all localities")
+		return result, nil
 	}
 
-	l, _ := s.rpGeo.FindLocalityById(ctx, *localityID)
+	s.logger.Debug(ctx, "carry-service", "Generating report for specific locality", map[string]interface{}{
+		"locality_id": *localityID,
+	})
+
+	// Validate that locality exists
+	l, err := s.rpGeo.FindLocalityById(ctx, *localityID)
+	if err != nil {
+		s.logger.Error(ctx, "carry-service", "Error while validating locality", err, map[string]interface{}{
+			"locality_id": *localityID,
+		})
+		return nil, err
+	}
+
 	if l == nil {
+		s.logger.Warning(ctx, "carry-service", "Locality not found", map[string]interface{}{
+			"locality_id": *localityID,
+		})
 		return nil, apperrors.NewAppError(apperrors.CodeNotFound, "locality not found")
 	}
-	return s.rp.GetCarriesCountByLocalityID(ctx, *localityID)
+
+	s.logger.Debug(ctx, "carry-service", "Locality validation successful", map[string]interface{}{
+		"locality_id":   *localityID,
+		"locality_name": l.Name,
+	})
+
+	result, err := s.rp.GetCarriesCountByLocalityID(ctx, *localityID)
+	if err != nil {
+		s.logger.Error(ctx, "carry-service", "Failed to get carries count for specific locality", err, map[string]interface{}{
+			"locality_id": *localityID,
+		})
+		return nil, err
+	}
+
+	s.logger.Info(ctx, "carry-service", "Successfully generated report for specific locality", map[string]interface{}{
+		"locality_id": *localityID,
+	})
+	return result, nil
 }

--- a/internal/service/carry/carry_interface.go
+++ b/internal/service/carry/carry_interface.go
@@ -6,6 +6,7 @@ import (
 	carryRepo "github.com/varobledo_meli/W17-G10-Bootcamp.git/internal/repository/carry"
 	geographyRepo "github.com/varobledo_meli/W17-G10-Bootcamp.git/internal/repository/geography"
 	"github.com/varobledo_meli/W17-G10-Bootcamp.git/pkg/models/carry"
+	"github.com/varobledo_meli/W17-G10-Bootcamp.git/pkg/logger"
 )
 
 type CarryService interface {
@@ -16,6 +17,7 @@ type CarryService interface {
 type CarryDefault struct {
 	rp    carryRepo.CarryRepository
 	rpGeo geographyRepo.GeographyRepository
+	logger logger.Logger
 }
 
 func NewCarryService(rp carryRepo.CarryRepository, rpGeo geographyRepo.GeographyRepository) *CarryDefault {
@@ -23,4 +25,9 @@ func NewCarryService(rp carryRepo.CarryRepository, rpGeo geographyRepo.Geography
 		rp:    rp,
 		rpGeo: rpGeo,
 	}
+}
+
+// SetLogger allows you to inject the logger after creation
+func (s *CarryDefault) SetLogger(l logger.Logger) {
+	s.logger = l
 }


### PR DESCRIPTION
Add Logging Support and Carries Report Endpoint Enhancement for Carrier Module
Summary
This PR introduces extensive improvements to the Carrier (“Carry”) module, including:

Logger Injection: Adds the ability to inject a logger instance for handlers, repositories, and services related to carriers via SetLogger methods.
Request Logging: Implements detailed logging at critical points of carry creation and reporting for improved traceability and error diagnostics.
Carries Report Endpoint: Adds a ReportCarries handler, allowing reporting on carrier counts grouped by locality, with optional locality filtering.
Repository Enhancements: Implements methods to fetch carrier counts, both globally (all localities) and by specific locality, with error handling and logging for database operations.
Service Layer Improvements: Adds service logic for the new report feature, including validation of input locality and corresponding logs for success or failure.
General Refactoring: Code organization improvements, better error handling responses, and clearer data flow between handlers, services, and repositories.
Motivation
Improves observability and maintainability by centralizing logger support.
Provides the operations/admin team with the ability to report on carriers by locality (or across all localities).
Ensures that all carry-related endpoints are robust, logged, and easier to debug.
Implementation Details
Logger injection: All main Carry components (Handler, Service, Repository) now allow injecting a logger post-instantiation.
Reporting logic: If a locality_id parameter is provided, the system validates its existence before querying. Reports return either a count for all localities or a specific one.
Error handling: Propagates and logs errors at every layer, and returns appropriate HTTP responses.
Backwards compatibility: Existing carry creation logic remains unchanged except for enhanced logging and error reporting.
Testing
Manually tested endpoints for creation and reporting, both with and without locality filters, and for failure modes (e.g., duplicate CID, invalid locality).